### PR TITLE
Check all titles in AniList

### DIFF
--- a/Api/Anilist/AniListApiCalls.cs
+++ b/Api/Anilist/AniListApiCalls.cs
@@ -56,6 +56,7 @@ namespace jellyfin_ani_sync.Api.Anilist {
                         native
                             userPreferred
                     },
+                    synonyms
                     episodes
                     status
                 }

--- a/Helpers/ApiCallHelpers.cs
+++ b/Helpers/ApiCallHelpers.cs
@@ -38,16 +38,18 @@ namespace jellyfin_ani_sync.Helpers {
                 List<Anime> convertedList = new List<Anime>();
                 if (animeList != null) {
                     foreach (AniListSearch.Media media in animeList) {
+                        var synonyms = new List<string> {
+                            { media.Title.Romaji },
+                            { media.Title.UserPreferred }
+                        };
+                        synonyms.AddRange(media.Synonyms);
                         var anime = new Anime {
                             Id = media.Id,
                             Title = media.Title.English,
                             AlternativeTitles = new AlternativeTitles {
                                 En = media.Title.English,
                                 Ja = media.Title.Native,
-                                Synonyms = new List<string> {
-                                    { media.Title.Romaji },
-                                    { media.Title.UserPreferred }
-                                }
+                                Synonyms = synonyms
                             },
                             NumEpisodes = media.Episodes ?? 0,
                         };

--- a/Models/AniList/AniListSearch.cs
+++ b/Models/AniList/AniListSearch.cs
@@ -68,6 +68,8 @@ namespace jellyfin_ani_sync.Models {
 
             [JsonPropertyName("title")] public Title Title { get; set; }
 
+            [JsonPropertyName("synonyms")] public List<string> Synonyms { get; set; }
+
             [JsonPropertyName("episodes")] public int? Episodes { get; set; }
 
             [JsonPropertyName("mediaListEntry")] public MediaListEntry? MediaListEntry { get; set; }

--- a/ServerEntry.cs
+++ b/ServerEntry.cs
@@ -196,9 +196,11 @@ namespace jellyfin_ani_sync {
         /// <param name="movie">The movie if its a single episode movie.</param>
         /// <returns></returns>
         private bool TitleCheck(Anime anime, Episode episode, Movie movie) {
-            return CompareStrings(anime.Title, _animeType == typeof(Episode) ? episode.SeriesName : movie.Name) ||
-                   CompareStrings(anime.AlternativeTitles.En, _animeType == typeof(Episode) ? episode.SeriesName : movie.Name) ||
-                   (anime.AlternativeTitles.Ja != null && CompareStrings(anime.AlternativeTitles.Ja, _animeType == typeof(Episode) ? episode.SeriesName : movie.Name));
+            var title = _animeType == typeof(Episode) ? episode.SeriesName : movie.Name;
+            return CompareStrings(anime.Title, title) ||
+                   CompareStrings(anime.AlternativeTitles.En, title) ||
+                   (anime.AlternativeTitles.Ja != null && CompareStrings(anime.AlternativeTitles.Ja, title)) ||
+                   (anime.AlternativeTitles.Synonyms != null && anime.AlternativeTitles.Synonyms.Any(synonym => CompareStrings(synonym, title)));
         }
 
         /// <summary>


### PR DESCRIPTION
In AniList, some anime do not have an english title (such as Aikatsu! or PriPara).
Thus, the title check will only check against the japanese title, which in the case of using either english or romaji folder names means the series won't be found.

Moreover, some series have a different english title on AniList compared to some databases (Case Closed (Meitantei Conan for romaji) being called Detective Conan on TVDB for example).
These series won't be found either.

This PR intends to fix these issues with the following measures:
- Check the romaji title, which is already in Anime.AlternativeTitles.Synonyms (seemed to never be used)
- Add AniList's synonyms to Anime.AlternativeTitles.Synonyms
- As Anime.Title is empty for these anime, try to get an alternative title for the logs: the first synonym (so most likely romaji) or the japanese title if no synonym