### PR TITLE
Don't run on PR from repo fork

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,7 @@ jobs:
         uses: docker/setup-buildx-action@v3.0.0
 
       - name: Log into registry ${{ env.REGISTRY }}
+        if: ${{ !github.event.pull_request || github.event.pull_request.base.repo == github.event.pull_request.head.repo }}
         uses: docker/login-action@v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -68,14 +69,16 @@ jobs:
           platforms: ${{ matrix.platform }}
           provenance: true
           sbom: true
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ !github.event.pull_request || github.event.pull_request.base.repo == github.event.pull_request.head.repo }}
 
       - name: Export digest
+        if: ${{ !github.event.pull_request || github.event.pull_request.base.repo == github.event.pull_request.head.repo }}
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
       - name: Upload digest
+        if: ${{ !github.event.pull_request || github.event.pull_request.base.repo == github.event.pull_request.head.repo }}
         uses: actions/upload-artifact@v3
         with:
           name: digests
@@ -85,6 +88,7 @@ jobs:
 
   merge:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request || github.event.pull_request.base.repo == github.event.pull_request.head.repo }}
     needs:
       - build
     permissions:


### PR DESCRIPTION
Upon further digging, I discovered that it is [impossible](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) for forks of public repos to write back to the original.