### PR TITLE
Fix tag detection

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Build Docker Container
 on:
   push:
     branches: ['**']
-    tags: ["*.*.*"]
+    tags: ["v*.*"]
   pull_request:
     branches: ["master"]
   schedule:


### PR DESCRIPTION
The Docker script doesn't run correctly on tags that don't have the patch component (`x.y.z` where z is the patch number), so this updates it.