### PR TITLE
fix: anilist page incrementation

### DIFF
--- a/Api/Anilist/AniListApiCalls.cs
+++ b/Api/Anilist/AniListApiCalls.cs
@@ -81,6 +81,8 @@ namespace jellyfin_ani_sync.Api.Anilist {
                     // impose a hard limit of 10 pages
                     while (page < 10) {
                         page++;
+                        variables["page"] = page.ToString();
+                        
                         AniListSearch.AniListSearchMedia nextPageResult = await GraphQlHelper.DeserializeRequest<AniListSearch.AniListSearchMedia>(_httpClient, query, variables);
 
                         result.Data.Page.Media = result.Data.Page.Media.Concat(nextPageResult.Data.Page.Media).ToList();
@@ -267,6 +269,8 @@ namespace jellyfin_ani_sync.Api.Anilist {
                     // impose a hard limit of 10 pages
                     while (page < 100) {
                         page++;
+                        variables["page"] = page.ToString();
+                        
                         AniListMediaList.AniListUserMediaList nextPageResult = await GraphQlHelper.DeserializeRequest<AniListMediaList.AniListUserMediaList>(_httpClient, query, variables);
 
                         result.Data.Page.MediaList = result.Data.Page.MediaList.Concat(nextPageResult.Data.Page.MediaList).ToList();


### PR DESCRIPTION
I encountered an issue with the Manual Sync feature for anilist, where it was failing after a few seconds. I looked into code and the root cause is as an oversight in the "GetAnimeList" function for anilist. This seems to occur when users have enough animes that multiple pages of data need to be fetched.

The code was correctly incrementing the page value for each iteration, but it was not passing this updated value to the api call. As such, the same page was being request over and over again, resulting in the eventual error.

To fix this, I have modified the code to update the variable passed to the api call. This fix resolves the error and the manual sync seems to work now. Also I noticed that another function "SearchAnime" also had this issue so I fixed it there too.

While I have fixed the issue, I am not entirely sure about the nature of the error itself. In theory, it should have resulted in duplicate data rather than an error. I suspect that the API calls might have been rate-limited because after 30 requests I got an NullReferenceException. It would be worthwhile to investigate this further and maybe raise the amount of time to sleep between each iteration, as maybe users with even more animes in their list might encounter the error. If you want to I can look into this further when I have time.