### PR TITLE
Update vulnerable nuget packages

### DIFF
--- a/jellyfin-ani-sync.csproj
+++ b/jellyfin-ani-sync.csproj
@@ -14,8 +14,8 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.8.4" />
-    <PackageReference Include="Jellyfin.Model" Version="10.8.4" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.8.13" />
+    <PackageReference Include="Jellyfin.Model" Version="10.8.13" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
             <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
             <PackageReference Include="System.Collections" Version="4.3.0" />


### PR DESCRIPTION
- Vulnerability Report: https://github.com/advisories/GHSA-9p5f-5x8v-x65m
- Tested using Jellyfin 10.8.13 in a docker container, no issues found after updating nuget packages