### PR TITLE
Anilist "GetAnimeList" fixes

### DIFF
--- a/Api/Anilist/AniListApiCalls.cs
+++ b/Api/Anilist/AniListApiCalls.cs
@@ -268,7 +268,7 @@ namespace jellyfin_ani_sync.Api.Anilist {
                     // impose a hard limit of 10 pages
                     while (page < 10) {
                         page++;
-                        variables["page"] = page.ToString();
+                        variables["chunk"] = page.ToString();
 
                         AniListMediaList.AniListUserMediaList nextPageResult = await GraphQlHelper.DeserializeRequest<AniListMediaList.AniListUserMediaList>(_httpClient, query, variables);
 

--- a/Api/Anilist/AniListApiCalls.cs
+++ b/Api/Anilist/AniListApiCalls.cs
@@ -278,7 +278,7 @@ namespace jellyfin_ani_sync.Api.Anilist {
                         }
 
                         // sleeping thread so we dont hammer the API
-                        Thread.Sleep(1000);
+                        Thread.Sleep(2000);
                     }
                 }
 

--- a/Helpers/ApiCallHelpers.cs
+++ b/Helpers/ApiCallHelpers.cs
@@ -562,7 +562,7 @@ namespace jellyfin_ani_sync.Helpers {
                             }
 
                             convertedList.Add(new Anime {
-                                Id = int.TryParse(media.Media.SiteUrl.Substring(lastIndex + 1, media.Media.SiteUrl.Length - lastIndex - 1), out int id) ? id : 0,
+                                Id = media.Media.Id,
                                 MyListStatus = new MyListStatus {
                                     FinishDate = finishDate.ToShortDateString(),
                                     NumEpisodesWatched = media.Progress ?? -1

--- a/Models/AniList/AniListMediaList.cs
+++ b/Models/AniList/AniListMediaList.cs
@@ -5,19 +5,23 @@ namespace jellyfin_ani_sync.Models;
 
 public class AniListMediaList {
     public class Data {
-        [JsonPropertyName("Page")] public Page Page { get; set; }
+        [JsonPropertyName("MediaListCollection")] public MediaListCollection MediaListCollection { get; set; }
     }
 
-    public class MediaList {
+    public class Entries {
         [JsonPropertyName("media")] public AniListSearch.Media Media { get; set; }
         [JsonPropertyName("completedAt")] public AniListSearch.FuzzyDate CompletedAt { get; set; }
         [JsonPropertyName("progress")] public int? Progress { get; set; }
     }
 
-    public class Page {
-        [JsonPropertyName("mediaList")] public List<MediaList> MediaList { get; set; }
+    public class EntriesContainer {
+        [JsonPropertyName("entries")] public List<Entries> Entries { get; set; }
+    }
 
-        [JsonPropertyName("pageInfo")] public AniListSearch.PageInfo PageInfo { get; set; }
+    public class MediaListCollection {
+        [JsonPropertyName("lists")] public List<EntriesContainer> MediaList { get; set; }
+
+        [JsonPropertyName("hasNextChunk")] public bool HasNextChunk { get; set; }
     }
 
     public class AniListUserMediaList {


### PR DESCRIPTION
This PR fixes the issue of hitting into a 429 during manual sync (fixes #109).

The fixes include:

1. Using the chunked graphql query to retrieve more results per API call.
2. Increasing sleep to 2000ms.

Also instead of parsing the ID from the site URL, we now just request it directly in the query.