### PR TITLE
Changes for Jellyfin 10.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 COPY . /app
 
-RUN dotnet publish --configuration Release --property:OutputPath=bin
+RUN dotnet publish --configuration Release --property:PublishDir=bin
 
 FROM alpine as final
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /app
 COPY . /app
 
-RUN dotnet publish --configuration Release --output bin
+RUN dotnet publish --configuration Release --property:OutputPath=bin
 
 FROM alpine as final
 WORKDIR /app

--- a/PluginServiceRegistrator.cs
+++ b/PluginServiceRegistrator.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace jellyfin_ani_sync;
 
-public class PluginServiceRegistrator :IPluginServiceRegistrator
+public class PluginServiceRegistrator : IPluginServiceRegistrator
 {
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
     {

--- a/PluginServiceRegistrator.cs
+++ b/PluginServiceRegistrator.cs
@@ -1,0 +1,14 @@
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace jellyfin_ani_sync;
+
+public class PluginServiceRegistrator :IPluginServiceRegistrator
+{
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        serviceCollection.AddHostedService<SessionServerEntry>();
+        serviceCollection.AddHostedService<UserDataServerEntry>();
+    }
+}

--- a/SessionServerEntry.cs
+++ b/SessionServerEntry.cs
@@ -1,18 +1,19 @@
 using System;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.IO;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync {
-    public class SessionServerEntry : IServerEntryPoint {
+    public class SessionServerEntry : IHostedService {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IServerApplicationHost _serverApplicationHost;
         private readonly IHttpContextAccessor _httpContextAccessor;
@@ -40,8 +41,13 @@ namespace jellyfin_ani_sync {
             _fileSystem = fileSystem;
         }
 
-        public Task RunAsync() {
+        public Task StartAsync(CancellationToken cancellationToken) {
             _sessionManager.PlaybackStopped += PlaybackStopped;
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) {
+            _sessionManager.PlaybackStopped -= PlaybackStopped;
             return Task.CompletedTask;
         }
 
@@ -54,12 +60,6 @@ namespace jellyfin_ani_sync {
             } catch (Exception exception) {
                 _logger.LogError($"Fatal error occured during anime sync job: {exception}");
             }
-        }
-
-
-        public void Dispose() {
-            _sessionManager.PlaybackStopped -= PlaybackStopped;
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/Sync/SyncProviderFromLocal.cs
+++ b/Sync/SyncProviderFromLocal.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Helpers;
+using Jellyfin.Data.Enums;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
@@ -94,7 +95,7 @@ public class SyncProviderFromLocal {
             }
             
             var query = new InternalItemsQuery(_userManager.GetUserById(_userId)) {
-                MediaTypes = new []{"Video"},
+                MediaTypes = [ MediaType.Video ],
                 ParentId = season.ParentId,
                 ParentIndexNumber = season.IndexNumber,
                 Recursive = true

--- a/build.yaml
+++ b/build.yaml
@@ -2,8 +2,8 @@
 name: "Ani-Sync"
 guid: "c78f11cf-93e6-4423-8c42-d2c255b70e47"
 version: "1.4"
-targetAbi: "10.8.0.0"
-framework: "net6.0"
+targetAbi: "10.9.0.0"
+framework: "net8.0"
 owner: "vosmiic"
 overview: "Synchronize anime watch status"
 description: >

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.0",
+    "version": "8.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }

--- a/jellyfin-ani-sync.csproj
+++ b/jellyfin-ani-sync.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>jellyfin_ani_sync</RootNamespace>
     </PropertyGroup>
 
@@ -14,10 +14,10 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.8.13" />
-    <PackageReference Include="Jellyfin.Model" Version="10.8.13" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.9.1" />
+    <PackageReference Include="Jellyfin.Model" Version="10.9.1" />
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
-            <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+            <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
             <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
     


### PR DESCRIPTION
- Now uses dotnet 8.0, same as Jellyfin 10.9
- Changed `IServerEntryPoint` into `IHostedService`
  -  `RunAsync` changed to `StartAsync`
  - `Dispose` changed to `StopAsync`
  - `GC.SuppressFinalize(this);` is not needed anymore
  - Added new class `PluginServiceRegistrator` to register `UserDataServerEntry` and `SessionServerEntry` , required for `IHostedService` to work. It doesn't work automatically like `IServerEntryPoint` had.
- `MediaTypes` now uses `MediaType` enum instead of `string`
- Tested on 10.9.1
- Fixes #124 
- Not sure if build.yaml is being used but changed it anyway