### PR TITLE
Fixing Anilist timeout issues

### DIFF
--- a/Api/AuthApiCall.cs
+++ b/Api/AuthApiCall.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Configuration;
 using jellyfin_ani_sync.Helpers;
+using jellyfin_ani_sync.Interfaces;
 using jellyfin_ani_sync.Models;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
@@ -23,15 +24,15 @@ namespace jellyfin_ani_sync.Api {
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<AuthApiCall> _logger;
         private readonly IMemoryCache _memoryCache;
+        private readonly IAsyncDelayer _delayer;
         public UserConfig UserConfig { get; set; }
 
-        public AuthApiCall(ApiName provider, IHttpClientFactory httpClientFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, ILoggerFactory loggerFactory, UserConfig userConfig) {
-            _provider = provider;
         public AuthApiCall(IHttpClientFactory httpClientFactory,
             IServerApplicationHost serverApplicationHost,
             IHttpContextAccessor httpContextAccessor,
             ILoggerFactory loggerFactory,
             IMemoryCache memoryCache,
+            IAsyncDelayer delayer,
             UserConfig userConfig) {
             _httpClientFactory = httpClientFactory;
             _serverApplicationHost = serverApplicationHost;

--- a/Api/AuthApiCall.cs
+++ b/Api/AuthApiCall.cs
@@ -6,32 +6,40 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
-using jellyfin_ani_sync.Api.Anilist;
 using jellyfin_ani_sync.Configuration;
 using jellyfin_ani_sync.Helpers;
 using jellyfin_ani_sync.Models;
 using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Api {
     public class AuthApiCall {
-        private ApiName _provider;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IServerApplicationHost _serverApplicationHost;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<AuthApiCall> _logger;
+        private readonly IMemoryCache _memoryCache;
         public UserConfig UserConfig { get; set; }
 
         public AuthApiCall(ApiName provider, IHttpClientFactory httpClientFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, ILoggerFactory loggerFactory, UserConfig userConfig) {
             _provider = provider;
+        public AuthApiCall(IHttpClientFactory httpClientFactory,
+            IServerApplicationHost serverApplicationHost,
+            IHttpContextAccessor httpContextAccessor,
+            ILoggerFactory loggerFactory,
+            IMemoryCache memoryCache,
+            UserConfig userConfig) {
             _httpClientFactory = httpClientFactory;
             _serverApplicationHost = serverApplicationHost;
             _httpContextAccessor = httpContextAccessor;
             _loggerFactory = loggerFactory;
             _logger = loggerFactory.CreateLogger<AuthApiCall>();
+            _memoryCache = memoryCache;
+            _delayer = delayer;
             UserConfig = userConfig;
         }
 
@@ -47,6 +55,7 @@ namespace jellyfin_ani_sync.Api {
         /// <exception cref="AuthenticationException">Could not authenticate with the API.</exception>
         public async Task<HttpResponseMessage?> AuthenticatedApiCall(ApiName provider, CallType callType, string url, FormUrlEncodedContent formUrlEncodedContent = null, StringContent stringContent = null, Dictionary<string, string>? requestHeaders = null) {
             int attempts = 0;
+            int timeoutSeconds = 4;
             UserApiAuth auth;
             try {
                 auth = UserConfig.UserApiAuth.FirstOrDefault(item => item.Name == provider);
@@ -56,8 +65,14 @@ namespace jellyfin_ani_sync.Api {
                 return null;
             }
 
-            while (attempts < 2) {
-                var client = _httpClientFactory.CreateClient(NamedClient.Default);
+            var client = _httpClientFactory.CreateClient(NamedClient.Default);
+            DateTime lastCallDateTime = _memoryCache.Get<DateTime>(MemoryCacheHelper.GetLastCallDateTimeKey(provider));
+            if (lastCallDateTime != default)
+            {
+                _logger.LogWarning($"({provider}) Delaying API call to prevent 429 (too many requests)...");
+                await _delayer.Delay(DateTime.UtcNow.Subtract(lastCallDateTime));
+            }
+            while (attempts < 3) {
                 if (requestHeaders != null) {
                     foreach (KeyValuePair<string,string> requestHeader in requestHeaders) {
                         client.DefaultRequestHeaders.Add(requestHeader.Key, requestHeader.Value);
@@ -67,6 +82,7 @@ namespace jellyfin_ani_sync.Api {
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth.AccessToken);
                 HttpResponseMessage responseMessage = new HttpResponseMessage();
                 try {
+                    _memoryCache.Set(MemoryCacheHelper.GetLastCallDateTimeKey(provider), DateTime.UtcNow, TimeSpan.FromSeconds(5));
                     switch (callType) {
                         case CallType.GET:
                             responseMessage = await client.GetAsync(url);
@@ -95,22 +111,31 @@ namespace jellyfin_ani_sync.Api {
                 if (responseMessage.IsSuccessStatusCode) {
                     return responseMessage;
                 } else {
-                    if (responseMessage.StatusCode == HttpStatusCode.Unauthorized) {
-                        // token has probably expired; try refreshing it
-                        UserApiAuth newAuth;
-                        try {
-                            newAuth = new ApiAuthentication(provider, _httpClientFactory, _serverApplicationHost, _httpContextAccessor, _loggerFactory).GetToken(UserConfig.UserId, refreshToken: auth.RefreshToken);
-                        } catch (Exception) {
-                            _logger.LogError("Could not re-authenticate. Please manually re-authenticate the user via the AniSync configuration page");
-                            return null;
-                        }
+                    switch (responseMessage.StatusCode)
+                    {
+                        case HttpStatusCode.Unauthorized:
+                            // token has probably expired; try refreshing it
+                            UserApiAuth newAuth;
+                            try {
+                                newAuth = new ApiAuthentication(provider, _httpClientFactory, _serverApplicationHost, _httpContextAccessor, _loggerFactory).GetToken(UserConfig.UserId, refreshToken: auth.RefreshToken);
+                            } catch (Exception) {
+                                _logger.LogError("Could not re-authenticate. Please manually re-authenticate the user via the AniSync configuration page");
+                                return null;
+                            }
 
-                        // and then make the call again, using the new auth details
-                        auth = newAuth;
-                        attempts++;
-                    } else {
-                        _logger.LogError($"Unable to complete {provider} API call ({callType.ToString()} {url}), reason: {responseMessage.StatusCode}; {responseMessage.ReasonPhrase}");
-                        return null;
+                            // and then make the call again, using the new auth details
+                            auth = newAuth;
+                            attempts++;
+                            break;
+                        case HttpStatusCode.TooManyRequests:
+                            _logger.LogWarning($"({provider}) API rate limit exceeded, retrying the API call again in {timeoutSeconds} seconds...");
+                            await _delayer.Delay(TimeSpan.FromSeconds(timeoutSeconds));
+                            timeoutSeconds *= 2;
+                            attempts++;
+                            break;
+                        default:
+                            _logger.LogError($"Unable to complete {provider} API call ({callType.ToString()} {url}), reason: {responseMessage.StatusCode}; {responseMessage.ReasonPhrase}");
+                            return null;
                     }
                 }
             }

--- a/Api/Kitsu/KitsuApiCalls.cs
+++ b/Api/Kitsu/KitsuApiCalls.cs
@@ -9,10 +9,12 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Configuration;
 using jellyfin_ani_sync.Helpers;
+using jellyfin_ani_sync.Interfaces;
 using jellyfin_ani_sync.Models;
 using jellyfin_ani_sync.Models.Kitsu;
 using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Api.Kitsu {
@@ -22,9 +24,9 @@ namespace jellyfin_ani_sync.Api.Kitsu {
         private readonly AuthApiCall _authApiCall;
         private readonly UserConfig _userConfig;
 
-        public KitsuApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, UserConfig userConfig) {
+        public KitsuApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, IMemoryCache memoryCache, IAsyncDelayer delayer, UserConfig userConfig) {
             _logger = loggerFactory.CreateLogger<KitsuApiCalls>();
-            _authApiCall = new AuthApiCall(ApiName.Kitsu, httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, userConfig: userConfig);
+            _authApiCall = new AuthApiCall(httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, memoryCache, delayer, userConfig: userConfig);
             _userConfig = userConfig;
         }
 

--- a/Api/Mal/MalApiCalls.cs
+++ b/Api/Mal/MalApiCalls.cs
@@ -2,21 +2,19 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Configuration;
 using jellyfin_ani_sync.Helpers;
+using jellyfin_ani_sync.Interfaces;
 using jellyfin_ani_sync.Models;
 using jellyfin_ani_sync.Models.Mal;
-using MediaBrowser.Common.Net;
 using MediaBrowser.Controller;
-using MediaBrowser.Controller.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Api {
@@ -29,9 +27,9 @@ namespace jellyfin_ani_sync.Api {
 
         private string ApiUrl => _apiBaseUrl + "v" + _apiVersion;
 
-        public MalApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, UserConfig userConfig = null) {
+        public MalApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, IMemoryCache memoryCache, IAsyncDelayer delayer, UserConfig userConfig = null) {
             _logger = loggerFactory.CreateLogger<MalApiCalls>();
-            _authApiCall = new AuthApiCall(ApiName.Mal, httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, userConfig: userConfig);
+            _authApiCall = new AuthApiCall(httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, memoryCache, delayer, userConfig: userConfig);
         }
 
         public class User {

--- a/Api/Shikimori/ShikimoriApiCalls.cs
+++ b/Api/Shikimori/ShikimoriApiCalls.cs
@@ -25,7 +25,6 @@ public class ShikimoriApiCalls {
     private readonly AuthApiCall _authApiCall;
     private readonly string _refreshTokenUrl = "https://shikimori.one/oauth/token";
     private readonly string _apiBaseUrl = "https://shikimori.one/api";
-    private readonly int _sleepDelay = 1000;
     private readonly UserConfig? _userConfig;
     private readonly Dictionary<string, string>? _requestHeaders;
 
@@ -167,9 +166,6 @@ public class ShikimoriApiCalls {
             if (animes.Count < limit) {
                 break;
             }
-
-            // sleeping task so we dont hammer the API
-            await Task.Delay(_sleepDelay);
         }
         return result;
     }
@@ -258,8 +254,6 @@ public class ShikimoriApiCalls {
             if (animes.Count < limit) {
                 break;
             }
-
-            await Task.Delay(_sleepDelay);
         }
         return result;
     }

--- a/Api/Shikimori/ShikimoriApiCalls.cs
+++ b/Api/Shikimori/ShikimoriApiCalls.cs
@@ -7,14 +7,15 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Threading;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Configuration;
 using jellyfin_ani_sync.Helpers;
+using jellyfin_ani_sync.Interfaces;
 using jellyfin_ani_sync.Models;
 using jellyfin_ani_sync.Models.Shikimori;
 using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Api.Shikimori;
@@ -80,11 +81,11 @@ public class ShikimoriApiCalls {
       }
     ";
 
-    public ShikimoriApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, Dictionary<string, string>? requestHeaders, UserConfig? userConfig = null) {
+    public ShikimoriApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, IMemoryCache memoryCache, IAsyncDelayer delayer, Dictionary<string, string>? requestHeaders, UserConfig? userConfig = null) {
         _userConfig = userConfig;
         _requestHeaders = requestHeaders;
         _logger = loggerFactory.CreateLogger<ShikimoriApiCalls>();
-        _authApiCall = new AuthApiCall(ApiName.Shikimori, httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, userConfig: userConfig);
+        _authApiCall = new AuthApiCall(httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, memoryCache, delayer, userConfig: userConfig);
     }
 
     public class User {

--- a/Api/Simkl/SimklApiCalls.cs
+++ b/Api/Simkl/SimklApiCalls.cs
@@ -110,9 +110,6 @@ public class SimklApiCalls {
                     break;
                 }
             }
-
-            // sleeping task so we dont hammer the API
-            await Task.Delay(1000);
         }
 
         return result;

--- a/Api/Simkl/SimklApiCalls.cs
+++ b/Api/Simkl/SimklApiCalls.cs
@@ -9,32 +9,26 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Configuration;
 using jellyfin_ani_sync.Helpers;
+using jellyfin_ani_sync.Interfaces;
 using jellyfin_ani_sync.Models;
 using jellyfin_ani_sync.Models.Simkl;
 using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Api.Simkl;
 
 public class SimklApiCalls {
-    private readonly IHttpClientFactory _httpClientFactory;
-    private readonly IServerApplicationHost _serverApplicationHost;
-    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly Dictionary<string, string> _requestHeaders;
-    private readonly UserConfig _userConfig;
     private readonly ILogger<SimklApiCalls> _logger;
     private readonly AuthApiCall _authApiCall;
     public static readonly string ApiBaseUrl = "https://api.simkl.com";
 
-    public SimklApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, Dictionary<string, string>? requestHeaders, UserConfig? userConfig = null) {
-        _httpClientFactory = httpClientFactory;
-        _serverApplicationHost = serverApplicationHost;
-        _httpContextAccessor = httpContextAccessor;
+    public SimklApiCalls(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, IMemoryCache memoryCache, IAsyncDelayer delayer, Dictionary<string, string>? requestHeaders, UserConfig? userConfig = null) {
         _requestHeaders = requestHeaders;
-        _userConfig = userConfig;
         _logger = loggerFactory.CreateLogger<SimklApiCalls>();
-        _authApiCall = new AuthApiCall(ApiName.Simkl, httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, userConfig: userConfig);
+        _authApiCall = new AuthApiCall(httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, memoryCache, delayer, userConfig: userConfig);
     }
 
     /// <summary>

--- a/Helpers/GraphQlHelper.cs
+++ b/Helpers/GraphQlHelper.cs
@@ -7,9 +7,11 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Api;
 using jellyfin_ani_sync.Configuration;
+using jellyfin_ani_sync.Interfaces;
 using jellyfin_ani_sync.Models;
 using MediaBrowser.Controller;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Helpers {
@@ -20,8 +22,8 @@ namespace jellyfin_ani_sync.Helpers {
             return call.IsSuccessStatusCode ? call : null;
         }
 
-        public static async Task<HttpResponseMessage> AuthenticatedRequest(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, UserConfig userConfig, string query, ApiName provider, Dictionary<string, object> variables = null) {
-            AuthApiCall authApiCall = new AuthApiCall(provider, httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, userConfig);
+        public static async Task<HttpResponseMessage> AuthenticatedRequest(IHttpClientFactory httpClientFactory, ILoggerFactory loggerFactory, IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor, IMemoryCache memoryCache, IAsyncDelayer delayer, UserConfig userConfig, string query, ApiName provider, Dictionary<string, object> variables = null) {
+            AuthApiCall authApiCall = new AuthApiCall(httpClientFactory, serverApplicationHost, httpContextAccessor, loggerFactory, memoryCache, delayer, userConfig);
             string url = string.Empty;
             switch (provider) {
                 case ApiName.AniList:

--- a/Helpers/MemoryCacheHelper.cs
+++ b/Helpers/MemoryCacheHelper.cs
@@ -1,0 +1,8 @@
+using jellyfin_ani_sync.Configuration;
+
+namespace jellyfin_ani_sync.Helpers;
+
+public class MemoryCacheHelper
+{
+    public static string GetLastCallDateTimeKey(ApiName provider) => $"{provider}LastCallDateTime";
+}

--- a/Interfaces/Delayer.cs
+++ b/Interfaces/Delayer.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Threading.Tasks;
+
+namespace jellyfin_ani_sync.Interfaces;
+
+public interface IAsyncDelayer
+{
+    Task Delay(TimeSpan timeSpan);
+}
+public class Delayer : IAsyncDelayer
+{
+    public async Task Delay(TimeSpan timeSpan)
+    {
+        await Task.Delay(timeSpan);
+    }
+}

--- a/SessionServerEntry.cs
+++ b/SessionServerEntry.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using jellyfin_ani_sync.Interfaces;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
@@ -9,6 +10,7 @@ using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.IO;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -21,6 +23,8 @@ namespace jellyfin_ani_sync {
         private readonly ILoggerFactory _loggerFactory;
         private readonly ISessionManager _sessionManager;
         private readonly ILogger<SessionServerEntry> _logger;
+        private readonly IMemoryCache _memoryCache;
+        private readonly IAsyncDelayer _delayer;
 
 
         private readonly ILibraryManager _libraryManager;
@@ -29,7 +33,7 @@ namespace jellyfin_ani_sync {
         public SessionServerEntry(ISessionManager sessionManager, ILoggerFactory loggerFactory,
             IHttpClientFactory httpClientFactory, ILibraryManager libraryManager, IFileSystem fileSystem,
             IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor,
-            IApplicationPaths applicationPaths) {
+            IApplicationPaths applicationPaths, IMemoryCache memoryCache, IAsyncDelayer delayer) {
             _httpClientFactory = httpClientFactory;
             _serverApplicationHost = serverApplicationHost;
             _httpContextAccessor = httpContextAccessor;
@@ -39,6 +43,8 @@ namespace jellyfin_ani_sync {
             _sessionManager = sessionManager;
             _libraryManager = libraryManager;
             _fileSystem = fileSystem;
+            _memoryCache = memoryCache;
+            _delayer = delayer;
         }
 
         public Task StartAsync(CancellationToken cancellationToken) {
@@ -53,7 +59,7 @@ namespace jellyfin_ani_sync {
 
         public async void PlaybackStopped(object sender, PlaybackStopEventArgs e) {
             try {
-                UpdateProviderStatus updateProviderStatus = new UpdateProviderStatus(_fileSystem, _libraryManager, _loggerFactory, _httpContextAccessor, _serverApplicationHost, _httpClientFactory, _applicationPaths);
+                UpdateProviderStatus updateProviderStatus = new UpdateProviderStatus(_fileSystem, _libraryManager, _loggerFactory, _httpContextAccessor, _serverApplicationHost, _httpClientFactory, _applicationPaths, _memoryCache, _delayer);
                 foreach (User user in e.Users) {
                     await updateProviderStatus.Update(e.Item, user.Id, e.PlayedToCompletion);
                 }

--- a/SessionServerEntry.cs
+++ b/SessionServerEntry.cs
@@ -33,7 +33,7 @@ namespace jellyfin_ani_sync {
         public SessionServerEntry(ISessionManager sessionManager, ILoggerFactory loggerFactory,
             IHttpClientFactory httpClientFactory, ILibraryManager libraryManager, IFileSystem fileSystem,
             IServerApplicationHost serverApplicationHost, IHttpContextAccessor httpContextAccessor,
-            IApplicationPaths applicationPaths, IMemoryCache memoryCache, IAsyncDelayer delayer) {
+            IApplicationPaths applicationPaths, IMemoryCache memoryCache) {
             _httpClientFactory = httpClientFactory;
             _serverApplicationHost = serverApplicationHost;
             _httpContextAccessor = httpContextAccessor;
@@ -44,7 +44,7 @@ namespace jellyfin_ani_sync {
             _libraryManager = libraryManager;
             _fileSystem = fileSystem;
             _memoryCache = memoryCache;
-            _delayer = delayer;
+            _delayer = new Delayer();
         }
 
         public Task StartAsync(CancellationToken cancellationToken) {

--- a/UserDataServerEntry.cs
+++ b/UserDataServerEntry.cs
@@ -2,12 +2,12 @@
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using jellyfin_ani_sync.Interfaces;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Library;
-using MediaBrowser.Controller.Plugins;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.IO;
 using Microsoft.AspNetCore.Http;
@@ -25,6 +25,7 @@ namespace jellyfin_ani_sync {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IMemoryCache _memoryCache;
         private readonly IApplicationPaths _applicationPaths;
+        private readonly IAsyncDelayer _delayer;
         private readonly TaskProcessMarkedMedia _taskProcessMarkedMedia;
         private Task? _updateTask;
 
@@ -46,7 +47,8 @@ namespace jellyfin_ani_sync {
             _httpClientFactory = httpClientFactory;
             _memoryCache = memoryCache;
             _applicationPaths = applicationPaths;
-            _taskProcessMarkedMedia = new TaskProcessMarkedMedia(loggerFactory, _libraryManager, _fileSystem, _memoryCache, _httpContextAccessor, _serverApplicationHost, _httpClientFactory, _applicationPaths);
+            _delayer = new Delayer();
+            _taskProcessMarkedMedia = new TaskProcessMarkedMedia(loggerFactory, _libraryManager, _fileSystem, _memoryCache, _httpContextAccessor, _serverApplicationHost, _httpClientFactory, _applicationPaths, _delayer);
         }
 
         public Task StartAsync(CancellationToken cancellationToken) {


### PR DESCRIPTION
This PR fixes AniList (and potential other provider) 429 too many request issues by implementing an exponential backoff and preventing too many API calls being made to the same provider if called in succession too quickly.

Also a delayer interface has been created for unit tests.

Fixes #122 