### PR TITLE
Frontend fixes

### DIFF
--- a/Api/AniSyncController.cs
+++ b/Api/AniSyncController.cs
@@ -73,6 +73,9 @@ namespace jellyfin_ani_sync.Api {
         [HttpGet]
         [Route("testAnimeListSaveLocation")]
         public async Task<IActionResult> TestAnimeSaveLocation(string saveLocation) {
+            if (String.IsNullOrEmpty(saveLocation))
+                return BadRequest("Save location is empty");
+            
             try {
                 await using (System.IO.File.Create(
                                  Path.Combine(

--- a/Api/AniSyncController.cs
+++ b/Api/AniSyncController.cs
@@ -17,16 +17,19 @@ using jellyfin_ani_sync.Api.Simkl;
 using jellyfin_ani_sync.Configuration;
 using jellyfin_ani_sync.Helpers;
 using jellyfin_ani_sync.Models;
+using MediaBrowser.Common.Api;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Model.IO;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Api {
     [ApiController]
+    [Authorize(Policy = Policies.RequiresElevation)]
     [Route("[controller]")]
     public class AniSyncController : ControllerBase {
         private readonly IHttpClientFactory _httpClientFactory;

--- a/Api/AniSyncController.cs
+++ b/Api/AniSyncController.cs
@@ -121,6 +121,7 @@ namespace jellyfin_ani_sync.Api {
             return Ok();
         }
 
+        [AllowAnonymous]
         [HttpGet]
         [Route("authCallback")]
         public IActionResult MalCallback(string code) {

--- a/Api/AniSyncController.cs
+++ b/Api/AniSyncController.cs
@@ -162,7 +162,8 @@ namespace jellyfin_ani_sync.Api {
                 case ApiName.Mal:
                     MalApiCalls malApiCalls = new MalApiCalls(_httpClientFactory, _loggerFactory, _serverApplicationHost, _httpContextAccessor, Plugin.Instance.PluginConfiguration.UserConfig.FirstOrDefault(item => item.UserId == Guid.Parse(userId)));
 
-                    return new OkObjectResult(await malApiCalls.GetUserInformation());
+                    MalApiCalls.User? malUser = await malApiCalls.GetUserInformation();
+                    return malUser != null ? new OkObjectResult(malUser) : StatusCode(500, "Authentication failed");
                 case ApiName.AniList:
                     AniListApiCalls aniListApiCalls = new AniListApiCalls(_httpClientFactory, _loggerFactory, _serverApplicationHost, _httpContextAccessor, Plugin.Instance.PluginConfiguration.UserConfig.FirstOrDefault(item => item.UserId == Guid.Parse(userId)));
 

--- a/Api/AniSyncController.cs
+++ b/Api/AniSyncController.cs
@@ -141,7 +141,7 @@ namespace jellyfin_ani_sync.Api {
                     }
                 }
 
-                return Ok();
+                return new ObjectResult("Success! Received access token, please contact the Jellyfin administrator to test the authentication.") { StatusCode = 200 };
             } else {
                 _logger.LogError("Authenticated user ID could not be found in the configuration. Please regenerate the authentication URL and try again");
                 return StatusCode(500);

--- a/Api/AniSyncController.cs
+++ b/Api/AniSyncController.cs
@@ -95,28 +95,30 @@ namespace jellyfin_ani_sync.Api {
         [HttpGet]
         [Route("passwordGrant")]
         public async Task<IActionResult> PasswordGrantAuthentication(ApiName provider, string userId, string username, string password) {
-            if (new ApiAuthentication(provider, _httpClientFactory, _serverApplicationHost, _httpContextAccessor, _loggerFactory, new ProviderApiAuth { ClientId = username, ClientSecret = password }).GetToken(Guid.Parse(userId)) != null) {
-                if (provider == ApiName.Kitsu) {
-                    var userConfig = Plugin.Instance.PluginConfiguration.UserConfig.FirstOrDefault(item => item.UserId == Guid.Parse(userId));
-
-                    if (userConfig != null) {
-                        KitsuApiCalls kitsuApiCalls = new KitsuApiCalls(_httpClientFactory, _loggerFactory, _serverApplicationHost, _httpContextAccessor, userConfig);
-                        var kitsuUserConfig = await kitsuApiCalls.GetUserInformation();
-                        var existingKeyPair = userConfig.KeyPairs.FirstOrDefault(item => item.Key == "KitsuUserId");
-                        if (existingKeyPair != null) {
-                            existingKeyPair.Value = kitsuUserConfig.Id.ToString();
-                        } else {
-                            userConfig.KeyPairs.Add(new KeyPairs { Key = "KitsuUserId", Value = kitsuUserConfig.Id.ToString() });
-                        }
-
-                        Plugin.Instance.SaveConfiguration();
-                    }
-                }
-
-                return Ok();
+            try {
+                new ApiAuthentication(provider, _httpClientFactory, _serverApplicationHost, _httpContextAccessor, _loggerFactory, new ProviderApiAuth { ClientId = username, ClientSecret = password }).GetToken(Guid.Parse(userId));
+            } catch (Exception e) {
+                return StatusCode(500, $"Could not authenticate; {e.Message}");
             }
 
-            return BadRequest();
+            if (provider == ApiName.Kitsu) {
+                var userConfig = Plugin.Instance.PluginConfiguration.UserConfig.FirstOrDefault(item => item.UserId == Guid.Parse(userId));
+
+                if (userConfig != null) {
+                    KitsuApiCalls kitsuApiCalls = new KitsuApiCalls(_httpClientFactory, _loggerFactory, _serverApplicationHost, _httpContextAccessor, userConfig);
+                    var kitsuUserConfig = await kitsuApiCalls.GetUserInformation();
+                    var existingKeyPair = userConfig.KeyPairs.FirstOrDefault(item => item.Key == "KitsuUserId");
+                    if (existingKeyPair != null) {
+                        existingKeyPair.Value = kitsuUserConfig.Id.ToString();
+                    } else {
+                        userConfig.KeyPairs.Add(new KeyPairs { Key = "KitsuUserId", Value = kitsuUserConfig.Id.ToString() });
+                    }
+
+                    Plugin.Instance.SaveConfiguration();
+                }
+            }
+
+            return Ok();
         }
 
         [HttpGet]

--- a/Api/AniSyncController.cs
+++ b/Api/AniSyncController.cs
@@ -114,6 +114,8 @@ namespace jellyfin_ani_sync.Api {
                     if (userConfig != null) {
                         KitsuApiCalls kitsuApiCalls = new KitsuApiCalls(_httpClientFactory, _loggerFactory, _serverApplicationHost, _httpContextAccessor, _memoryCache, _delayer, userConfig);
                         var kitsuUserConfig = await kitsuApiCalls.GetUserInformation();
+                        if (kitsuUserConfig == null)
+                            return StatusCode(500, "Could not authenticate");
                         var existingKeyPair = userConfig.KeyPairs.FirstOrDefault(item => item.Key == "KitsuUserId");
                         if (existingKeyPair != null) {
                             existingKeyPair.Value = kitsuUserConfig.Id.ToString();

--- a/Api/AuthApiCall.cs
+++ b/Api/AuthApiCall.cs
@@ -97,8 +97,8 @@ namespace jellyfin_ani_sync.Api {
                         UserApiAuth newAuth;
                         try {
                             newAuth = new ApiAuthentication(provider, _httpClientFactory, _serverApplicationHost, _httpContextAccessor, _loggerFactory).GetToken(UserConfig.UserId, refreshToken: auth.RefreshToken);
-                        } catch (Exception) {
-                            _logger.LogError("Could not re-authenticate. Please manually re-authenticate the user via the AniSync configuration page");
+                        } catch (Exception e) {
+                            _logger.LogError($"Could not re-authenticate: {e.Message}, please manually re-authenticate the user via the AniSync configuration page");
                             return null;
                         }
 

--- a/Api/AuthApiCall.cs
+++ b/Api/AuthApiCall.cs
@@ -47,11 +47,8 @@ namespace jellyfin_ani_sync.Api {
         /// <exception cref="AuthenticationException">Could not authenticate with the API.</exception>
         public async Task<HttpResponseMessage?> AuthenticatedApiCall(ApiName provider, CallType callType, string url, FormUrlEncodedContent formUrlEncodedContent = null, StringContent stringContent = null, Dictionary<string, string>? requestHeaders = null) {
             int attempts = 0;
-            UserApiAuth auth;
-            try {
-                auth = UserConfig.UserApiAuth.FirstOrDefault(item => item.Name == provider);
-                if (auth == null || auth.AccessToken == null) throw new NullReferenceException();
-            } catch (NullReferenceException) {
+            UserApiAuth? auth = UserConfig.UserApiAuth?.FirstOrDefault(item => item.Name == provider);
+            if (auth == null) {
                 _logger.LogError("Could not find authentication details, please authenticate the plugin first");
                 return null;
             }

--- a/Configuration/CommonJs.js
+++ b/Configuration/CommonJs.js
@@ -1,0 +1,60 @@
+// below tab functionality is heavily influenced by the tabs used in jellyfin-plugin-media-cleaner: https://github.com/shemanaev/jellyfin-plugin-media-cleaner
+
+export function getTabs() {
+    const tabs = [
+        {
+            href: configurationPageUrl('Ani-Sync'),
+            name: 'General'
+        },
+        {
+            href: configurationPageUrl('AniSync_ManualSync'),
+            name: 'Manual Sync'
+        }
+    ];
+    return tabs;
+}
+
+export function setTabs(selectedIndex, itemsFn) {
+    const $tabs = document.querySelector('.pluginConfigurationPage:not(.hide) #navigationTabs');
+    $tabs.innerHTML = '';
+
+    let i = 0;
+    for (const tab of itemsFn()) {
+        const elem = document.createElement("a");
+        elem.innerHTML = tab.name;
+        elem.addEventListener('click', (e) => Dashboard.navigate('/' + tab.href, false));
+        elem.className = 'emby-button' + (i === selectedIndex ? ' ui-btn-active' : '');
+        elem.dataset.role = 'button';
+
+        i++;
+        $tabs.appendChild(elem);
+    }
+}
+
+export const TabGeneral = 0;
+export const TabManualSync = 1;
+
+const configurationPageUrl = (name) => 'configurationpage?name=' + encodeURIComponent(name);
+
+export function setProviderSelection(page, providerList, providerListSelectElement) {
+    var html = '';
+    for (var x = 0; x < providerList.length; x++) {
+        html += '<option value="' + providerList[x].Key + '">' + providerList[x].Name + '</option>';
+    }
+    page.querySelector(providerListSelectElement).innerHTML = html;
+}
+
+export function populateUserList(page, users, userListSelectElement) {
+    var html = '';
+    for (var x = 0; x < users.length; x++) {
+        html += '<option value="' + users[x].Id + '">' + users[x].Name + '</option>';
+    }
+    page.querySelector(userListSelectElement).innerHTML = html;
+}
+
+export const parameterInclude = {
+    ProviderList: 0,
+    LocalIpAddress: 1,
+    LocalPort: 2,
+    Https: 3
+}

--- a/Configuration/ConfigPage.html
+++ b/Configuration/ConfigPage.html
@@ -1,14 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>Template</title>
-</head>
-<body>
-<div id="TemplateConfigPage" data-role="page" class="page type-interior pluginConfigurationPage"
-     data-require="emby-input,emby-button,emby-select,emby-checkbox" data-controller="__plugin/ConfigPageJs">
+<div id="TemplateConfigPage" data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+     data-require="emby-input,emby-button,emby-select,emby-checkbox" data-controller="__plugin/AniSync_ConfigPageJs">
     <div data-role="content">
         <div class="content-primary">
+            <div id="navigationTabs" data-role="controlgroup" data-type="horizontal" class="localnav"></div>
+            
             <form id="TemplateConfigForm">
                 <p>Please follow the <a href="https://github.com/vosmiic/jellyfin-ani-sync/wiki/Installation-&-Config">plugin
                     installation guide</a> for a more detailed explanation of what the below config options do.</p>
@@ -156,51 +151,7 @@
                         <span>Save</span>
                     </button>
                 </div>
-                <h2>Manual Sync</h2>
-                <p><b>Warning: this feature is in alpha, and bugs are probably present. In its current state it may disrupt your Jellyfin or provider library.</b></p>
-                <p>At the moment this functionality requires the AniList and/or AniDb metadata providers installed.</p>
-                <p>Here you can synchronize the selected users Jellyfin library and their provider list(s).</p>
-                <p>Updating the provider library with the users Jellyfin library will update all providers that the user is authenticated with.</p>
-                <p>This functionality is also loyal to the users configuration options (only update plan to watch, set as rewatching)</p>
-                <div class="inputContainer">
-                    <div class="selectContainer">
-                        <select is="emby-select" id="selectAction" name="selectAction" label="Select Action">
-                            <option value="UpdateJellyfin">Update Jellyfin with provider progress</option>
-                            <option value="UpdateProvider">Update provider with Jellyfin progress</option>
-                        </select>
-                    </div>
-                </div>
-                <div class="inputContainer">
-                    <div class="selectContainer">
-                        <select is="emby-select" id="selectSyncUser" name="selectUser" label="User"></select>
-                        <div class="fieldDescription">The user you would like to organize the library for. Only used when updating Jellyfin.</div>
-                    </div>
-                </div>
-                <div class="inputContainer">
-                    <div class="selectContainer">
-                        <select is="emby-select" id="selectSyncProvider" name="selectProvider" label="Provider"></select>
-                        <div class="fieldDescription">Provider to sync the anime list from. Only used when updating Jellyfin.</div>
-                    </div>
-                </div>
-                <div class="inputContainer">
-                    <div class="selectContainer">
-                        <select is="emby-select" id="status" name="status" label="Status">
-                            <option value="Completed">Completed (only fully completed shows and movies will be updated)</option>
-                            <option value="Watching">Watching (only currently being watched shows and movies will be updated)</option>
-                            <option value="Both">Completed and Watching (both watching and completed will be updated)</option>
-                        </select>
-                        <div class="fieldDescription">Status of the show on the users watch list you want to sync.</div>
-                    </div>
-                </div>
-                <div>
-                    <button is="emby-button" type="button" id="run" class="raised button-submit block emby-button">
-                        <span>Run</span>
-                    </button>
-                </div>
-                <p>This will run in the background. Please check the Jellyfin logs for operation progress.</p>
             </form>
         </div>
     </div>
 </div>
-</body>
-</html>

--- a/Configuration/ConfigPage.html
+++ b/Configuration/ConfigPage.html
@@ -81,12 +81,14 @@
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="clientId" id="clientIdLabel">Client ID</label>
                     <input id="clientId" name="clientId" type="text" is="emby-input"/>
+                    <span id="authorizeClientIdError"></span>
                     <div id="clientIdDescription" class="fieldDescription">The client ID from your provider application.</div>
                 </div>
                 <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="clientSecret" id="clientSecretLabel">Client
                         Secret</label>
                     <input id="clientSecret" name="clientSecret" type="password" is="emby-input"/>
+                    <span id="authorizeClientSecretError"></span>
                     <div id="clientSecretDescription" class="fieldDescription">The client secret from your provider application.<b>This value will be
                         stored in plain text in the plugin config. Make sure no untrusted users have access to the
                         file.</b></div>
@@ -116,6 +118,7 @@
                     authenticate one user at a time.<b>The access token will be stored in plain text in the plugin
                         config. Make sure no untrusted users have access to the file.</b></div>
                 <a id="authorizeLink"></a>
+                <span id="authorizeLinkGenerationNotification"></span>
                 <div id="testAuthenticationDescription" class="fieldDescription">Once you have authenticated your user, click the below button to test
                     the authentication:
                 </div>

--- a/Configuration/ConfigPageJs.js
+++ b/Configuration/ConfigPageJs.js
@@ -71,6 +71,17 @@ async function initialLoad(common) {
                     document.querySelector('#testAnimeListSaveLocationResponse').innerHTML = "Error: " + result;
                 }
             })
+            .catch((error) => {
+                Promise.resolve(error).then(async (resolvedError) => {
+                    if (typeof (resolvedError) === "string") {
+                        return resolvedError;
+                    } else {
+                        await resolvedError.text().then(error => {
+                            document.querySelector('#testAnimeListSaveLocationResponse').innerHTML = "Error: " +  error;
+                        });
+                    }
+                });
+            })
     }
 
 

--- a/Configuration/ConfigPageJs.js
+++ b/Configuration/ConfigPageJs.js
@@ -81,6 +81,11 @@ async function initialLoad(common) {
                         });
                     }
                 });
+
+                // reset save file path so the user doesn't accidentally save an invalid path
+                ApiClient.getPluginConfiguration(PluginConfig.pluginUniqueId).then(function (config) {
+                     document.querySelector('#animeListSaveLocation').value = config.animeListSaveLocation ?? '';
+                });
             })
     }
 

--- a/Configuration/ConfigPageJs.js
+++ b/Configuration/ConfigPageJs.js
@@ -75,8 +75,13 @@ async function initialLoad() {
 
     async function runTestAnimeListSaveLocation() {
         document.querySelector('#testAnimeListSaveLocationResponse').innerHTML = "Testing anime list save location..."
+        var location = document.querySelector('#animeListSaveLocation').value;
+        if (!location) {
+            document.querySelector('#testAnimeListSaveLocationResponse').innerHTML = "Error: Save location is empty";
+            return;
+        }
 
-        var url = ApiClient.getUrl("/AniSync/testAnimeListSaveLocation?saveLocation=" + encodeURIComponent(document.querySelector('#animeListSaveLocation').value));
+        var url = ApiClient.getUrl("/AniSync/testAnimeListSaveLocation?saveLocation=" + encodeURIComponent(location));
         await ApiClient.ajax({
             type: 'GET',
             url

--- a/Configuration/ConfigPageJs.js
+++ b/Configuration/ConfigPageJs.js
@@ -12,11 +12,13 @@ async function initialLoad() {
     const page = document;
     Dashboard.showLoadingMsg();
 
-    ApiClient.getUsers().then(function (users) {
-        populateUserList(page, users);
-        loadUserConfiguration(page.querySelector('#selectUser').value);
-        setUserAddress(page);
-    });
+    ApiClient.getUsers()
+        .then(function (users) {
+            populateUserList(page, users);
+            loadUserConfiguration(page.querySelector('#selectUser').value);
+            setUserAddress(page);
+        })
+        .catch(error => console.log("Could not populate users list: " + error));
 
     await setParameters(page);
     loadProviderConfiguration(page);
@@ -438,11 +440,13 @@ async function initialLoad() {
 
             ApiClient.updatePluginConfiguration(PluginConfig.pluginUniqueId, config).then(function (result) {
                 Dashboard.processPluginConfigurationUpdateResult(result);
-                ApiClient.getUsers().then(function (users) {
-                    populateUserList(users);
-                    document.querySelector('#selectUser').value = userId;
-                    loadUserConfiguration(userId);
-                });
+                ApiClient.getUsers()
+                    .then(function (users) {
+                        populateUserList(users);
+                        document.querySelector('#selectUser').value = userId;
+                        loadUserConfiguration(userId);
+                    })
+                    .catch(error => console.log("Could not populate users list: " + error));
             });
         });
     }

--- a/Configuration/ConfigPageJs.js
+++ b/Configuration/ConfigPageJs.js
@@ -131,7 +131,6 @@ async function initialLoad() {
         }
     }
 
-
     async function getUser() {
         document.querySelector('#getUserResponse').innerHTML = "Testing authentication.. this can take some time."
         if (document.querySelector('#selectProvider').value === "Annict")
@@ -156,6 +155,8 @@ async function initialLoad() {
                 } else {
                     document.querySelector('#getUserResponse').innerHTML = "Test returned an error - try authenticating again or check the logs for a detailed error reason."
                 }
+            }).catch(function (error) {
+                error.text().then(errorText => document.querySelector('#getUserResponse').innerHTML = "Test returned an error: " + errorText + "; try authenticating again or check the logs for a detailed error reason.")
             });
     }
 

--- a/Configuration/ManualSync.html
+++ b/Configuration/ManualSync.html
@@ -1,0 +1,52 @@
+<div id="ManualSyncConfigPage" data-role="page" class="page type-interior pluginConfigurationPage withTabs"
+     data-require="emby-input,emby-button,emby-select,emby-checkbox" data-controller="__plugin/AniSync_ManualSyncJs">
+    <div data-role="content">
+        <div class="content-primary">
+            <div id="navigationTabs" data-role="controlgroup" data-type="horizontal" class="localnav"></div>
+
+            <form id="ManualSyncConfigForm">
+                <p><b>Warning: this feature is in alpha, and bugs are probably present. In its current state it may disrupt your Jellyfin or provider library.</b></p>
+                <p>At the moment this functionality requires the AniList and/or AniDb metadata providers installed.</p>
+                <p>Here you can synchronize the selected users Jellyfin library and their provider list(s).</p>
+                <p>Updating the provider library with the users Jellyfin library will update all providers that the user is authenticated with.</p>
+                <p>This functionality is also loyal to the users configuration options (only update plan to watch, set as rewatching)</p>
+                <div class="inputContainer">
+                    <div class="selectContainer">
+                        <select is="emby-select" id="selectAction" name="selectAction" label="Select Action">
+                            <option value="UpdateJellyfin">Update Jellyfin with provider progress</option>
+                            <option value="UpdateProvider">Update provider with Jellyfin progress</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="inputContainer">
+                    <div class="selectContainer">
+                        <select is="emby-select" id="selectSyncUser" name="selectUser" label="User"></select>
+                        <div class="fieldDescription">The user you would like to organize the library for. Only used when updating Jellyfin.</div>
+                    </div>
+                </div>
+                <div class="inputContainer">
+                    <div class="selectContainer">
+                        <select is="emby-select" id="selectSyncProvider" name="selectProvider" label="Provider"></select>
+                        <div class="fieldDescription">Provider to sync the anime list from. Only used when updating Jellyfin.</div>
+                    </div>
+                </div>
+                <div class="inputContainer">
+                    <div class="selectContainer">
+                        <select is="emby-select" id="status" name="status" label="Status">
+                            <option value="Completed">Completed (only fully completed shows and movies will be updated)</option>
+                            <option value="Watching">Watching (only currently being watched shows and movies will be updated)</option>
+                            <option value="Both">Completed and Watching (both watching and completed will be updated)</option>
+                        </select>
+                        <div class="fieldDescription">Status of the show on the users watch list you want to sync.</div>
+                    </div>
+                </div>
+                <div>
+                    <p>This will run in the background. Please check the Jellyfin logs for operation progress.</p>
+                    <button is="emby-button" type="button" id="run" class="raised button-submit block emby-button">
+                        <span>Run</span>
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>

--- a/Configuration/ManualSyncJs.js
+++ b/Configuration/ManualSyncJs.js
@@ -1,0 +1,60 @@
+export default function (view, params) {
+    view.addEventListener('viewshow', async function () {
+        var generalFunctionsUrl = ApiClient.getUrl("web/ConfigurationPage", { name: "AniSync_CommonJs" });
+        import(generalFunctionsUrl).then(async (common) => await initialLoad(common))
+    });
+}
+async function initialLoad(common) {
+    const page = document;
+    common.setTabs(common.TabManualSync, common.getTabs);
+    
+    page.querySelector('#run').onclick = run;
+
+    page.querySelector('#selectAction').addEventListener('change', function (q) {
+        actionSelectionChange(page, q);
+    });
+
+    await setParameters(common, page);
+
+    ApiClient.getUsers()
+        .then(function (users) {
+            common.populateUserList(page, users, '#selectSyncUser');
+        })
+        .catch(error => console.log("Could not populate users list: " + error));
+    
+    function actionSelectionChange(page, value) {
+        switch (value.target.value) {
+            case "UpdateProvider":
+                page.querySelector('#selectSyncProvider').disabled = true;
+                page.querySelector('#status').disabled = true;
+                break;
+            case "UpdateJellyfin":
+                page.querySelector('#selectSyncProvider').disabled = false;
+                page.querySelector('#status').disabled = false;
+                break;
+        }
+    }
+}
+
+async function run() {
+    var url = ApiClient.getUrl("/AniSync/sync?provider=" + document.querySelector('#selectSyncProvider').value + "&userId=" + encodeURIComponent(document.querySelector('#selectSyncUser').value) + "&status=" + encodeURIComponent(document.querySelector('#status').value) + "&syncAction=" + encodeURIComponent(document.querySelector('#selectAction').value));
+    await ApiClient.ajax({
+        type: "POST",
+        url
+    });
+}
+
+async function setParameters(common, page) {
+    var url = ApiClient.getUrl("/AniSync/parameters?includes=" + common.parameterInclude.ProviderList);
+    await ApiClient.ajax({type: 'GET', url})
+        .then(function (response) {
+            if (response.ok) {
+                return response.json()
+                    .then(function (json) {
+                        common.setProviderSelection(page, json.providerList, '#selectSyncProvider');
+                    });
+            } else {
+                page.querySelector('#localApiUrl').innerHTML = "Could not fetch local URL.";
+            }
+        });
+}

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -29,8 +29,20 @@ namespace jellyfin_ani_sync {
                     EmbeddedResourcePath = $"{GetType().Namespace}.Configuration.ConfigPage.html"
                 },
                 new PluginPageInfo {
-                    Name = "ConfigPageJs",
+                    Name = "AniSync_ConfigPageJs",
                     EmbeddedResourcePath = $"{GetType().Namespace}.Configuration.ConfigPageJs.js"
+                },
+                new PluginPageInfo {
+                    Name = "AniSync_CommonJs",
+                    EmbeddedResourcePath = $"{GetType().Namespace}.Configuration.CommonJs.js"
+                },
+                new PluginPageInfo {
+                    Name = "AniSync_ManualSync",
+                    EmbeddedResourcePath = $"{GetType().Namespace}.Configuration.ManualSync.html"
+                },
+                new PluginPageInfo {
+                    Name = "AniSync_ManualSyncJs",
+                    EmbeddedResourcePath = $"{GetType().Namespace}.Configuration.ManualSyncJs.js"
                 }
             };
         }

--- a/jellyfin-ani-sync.csproj
+++ b/jellyfin-ani-sync.csproj
@@ -6,30 +6,36 @@
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <OutputPath>bin\Debug/</OutputPath>
+        <OutputPath>bin\Debug/</OutputPath>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-      <OutputPath>bin\Release/</OutputPath>
+        <OutputPath>bin\Release/</OutputPath>
     </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.9.1" />
-    <PackageReference Include="Jellyfin.Model" Version="10.9.1" />
-        <FrameworkReference Include="Microsoft.AspNetCore.App" />
-            <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-            <PackageReference Include="System.Collections" Version="4.3.0" />
-  </ItemGroup>
-    
-      <ItemGroup>
-    <None Remove="Configuration\ConfigPage.html" />
-    <EmbeddedResource Include="Configuration\ConfigPage.html" />
-    <None Remove="Configuration\ConfigPageJs.js" />
-    <EmbeddedResource Include="Configuration\ConfigPageJs.js" />
-  </ItemGroup>
-    
-      <ItemGroup>
-        <Compile Remove="builds\**" />
-      </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Jellyfin.Controller" Version="10.9.4"/>
+        <PackageReference Include="Jellyfin.Model" Version="10.9.4"/>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0"/>
+        <PackageReference Include="System.Collections" Version="4.3.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Remove="Configuration\ConfigPage.html"/>
+        <EmbeddedResource Include="Configuration\ConfigPage.html"/>
+        <None Remove="Configuration\ConfigPageJs.js"/>
+        <EmbeddedResource Include="Configuration\ConfigPageJs.js"/>
+        <None Remove="Configuration\CommonJs.js"/>
+        <EmbeddedResource Include="Configuration\CommonJs.js"/>
+        <None Remove="Configuration\ManualSync.html"/>
+        <EmbeddedResource Include="Configuration\ManualSync.html"/>
+        <None Remove="Configuration\ManualSyncJs.js"/>
+        <EmbeddedResource Include="Configuration\ManualSyncJs.js"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Remove="builds\**"/>
+    </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR adds various frontend fixes such as:

- Adding auth to all API calls that retrieve data.
- Error handling on frontend calls such as testing authentication, anime file path saving, generate auth link.
- Added tabs, manual sync is now in a separate tab.
- Config data is restored when loading config page (fixes #130).
- Potential fix for #126.