### PR TITLE
partially fix episode offsets

### DIFF
--- a/Helpers/AnimeOfflineDatabaseHelpers.cs
+++ b/Helpers/AnimeOfflineDatabaseHelpers.cs
@@ -9,7 +9,9 @@ using jellyfin_ani_sync.Configuration;
 namespace jellyfin_ani_sync.Helpers {
     public class AnimeOfflineDatabaseHelpers {
         public static async Task<OfflineDatabaseResponse> GetProviderIdsFromMetadataProvider(HttpClient httpClient, int metadataId, Source source) {
-            var response = await httpClient.GetAsync($"https://relations.yuna.moe/api/ids?source={source.ToString().ToLower()}&id={metadataId}");
+            // See https://arm.haglund.dev/docs#tag/v2/operation/v2-getIds
+            // TODO: make URL user-configurable to allow self-hosting the server.
+            var response = await httpClient.GetAsync($"https://arm.haglund.dev/api/v2/ids?source={source.ToString().ToLower()}&id={metadataId}");
             StreamReader streamReader = new StreamReader(await response.Content.ReadAsStreamAsync());
             string streamText = await streamReader.ReadToEndAsync();
 

--- a/UpdateProviderStatus.cs
+++ b/UpdateProviderStatus.cs
@@ -241,7 +241,11 @@ namespace jellyfin_ani_sync {
                                 _logger.LogInformation($"({_apiName}) Found matching {animeType}: {GetAnimeTitle(anime)}");
                                 Anime matchingAnime = anime;
                                 if (_animeType == typeof(Episode)) {
+                                    var episodeOffset = aniDbId.episodeOffset ?? 0;
                                     int episodeNumber = episode.IndexNumber.Value;
+                                    if (episodeOffset < episodeNumber) {
+                                        episodeNumber -= episodeOffset;
+                                    }
                                     if (!checkMalId) {
                                         // should have already found the appropriate series/season/movie, no need to do other checks
                                         if (episode?.Season.IndexNumber is > 1) {

--- a/UpdateProviderStatus.cs
+++ b/UpdateProviderStatus.cs
@@ -131,7 +131,7 @@ namespace jellyfin_ani_sync {
                         ? await AnimeListHelpers.GetAniDbId(_logger, _loggerFactory, _httpClientFactory, _applicationPaths, episode, episode.IndexNumber.Value, episode.Season.IndexNumber.Value, animeListXml)
                         : await AnimeListHelpers.GetAniDbId(_logger, _loggerFactory, _httpClientFactory, _applicationPaths, movie, movie.IndexNumber.Value, 1, animeListXml);
                     if (aniDbId.aniDbId != null) {
-                        _logger.LogInformation("Retrieving provider IDs from offline database...");
+                        _logger.LogInformation($"Retrieving provider IDs from offline database for AniDb ID {aniDbId.aniDbId.Value}...");
                         _apiIds = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClientFactory.CreateClient(NamedClient.Default), aniDbId.aniDbId.Value, AnimeOfflineDatabaseHelpers.Source.Anidb);
                         if (_apiIds is null) {
                             _apiIds = new AnimeOfflineDatabaseHelpers.OfflineDatabaseResponse {


### PR DESCRIPTION
This hopefully fixes some easy cases for episode offsets with recent sequels like Mushoku Tensei Season 2 Part 2 (in particular, for providers like Shikimori that rely heavily on external IDs, i.e. MAL in case of Shikimori).

Note that correct episode offset handling is more involved than what is currently implemented in this PR, see https://github.com/Anime-Lists/anime-lists?tab=readme-ov-file#format

---

<details>
<summary>Resolved issue with arm-server</summary>

For some reason https://arm.haglund.dev/api/ids?source=anidb&id=18104 returns `null`.

I’m not really sure what the issue is since we find the correct AniDB anime season from offline database (that is, https://anidb.net/anime/18104) and looks like https://github.com/Fribb/anime-lists (that https://github.com/BeeeQueue/arm-server is supposed to be using) defines mappings for other providers.

In addition to that, I’ve made these changes a few weeks ago and _IIRC_ arm-server API did not return null back then.

Same issue with https://anidb.net/anime/17431, 3rd konosuba season, i.e. https://arm.haglund.dev/api/ids?source=anidb&id=17431
</details>