### PR TITLE
fix: update kitsu api domain from kitsu.io to kitsu.app

### DIFF
--- a/jellyfin-ani-sync/Api/ApiAuthentication.cs
+++ b/jellyfin-ani-sync/Api/ApiAuthentication.cs
@@ -38,7 +38,7 @@ namespace jellyfin_ani_sync.Api {
                     _authApiUrl = "https://anilist.co/api/v2/oauth";
                     break;
                 case ApiName.Kitsu:
-                    _authApiUrl = "https://kitsu.io/api/oauth";
+                    _authApiUrl = "https://kitsu.app/api/oauth";
                     break;
                 case ApiName.Shikimori:
                     _authApiUrl = "https://shikimori.one/oauth";

--- a/jellyfin-ani-sync/Api/Kitsu/KitsuApiCalls.cs
+++ b/jellyfin-ani-sync/Api/Kitsu/KitsuApiCalls.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Api.Kitsu {
     public class KitsuApiCalls {
-        private readonly string ApiUrl = "https://kitsu.io/api/edge";
+        private readonly string ApiUrl = "https://kitsu.app/api/edge";
         private readonly ILogger<KitsuApiCalls> _logger;
         private readonly AuthApiCall _authApiCall;
         private readonly UserConfig _userConfig;


### PR DESCRIPTION
About a year ago, [Kitsu migrated from `kitsu.io` to `kitsu.app`](https://kitsu.app/posts/9837041). While `kitsu.io` redirects to `kitsu.app` for the time being, its probably best to point directly at the new domain. 