### PR TITLE
Allowing custom arm server usage

### DIFF
--- a/jellyfin-ani-sync-unit-tests/HelperTests/AnimeOfflineDatabaseHelperTests.cs
+++ b/jellyfin-ani-sync-unit-tests/HelperTests/AnimeOfflineDatabaseHelperTests.cs
@@ -4,12 +4,15 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Helpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace jellyfin_ani_sync_unit_tests.HelperTests;
 
 public class AnimeOfflineDatabaseHelperTests {
     private HttpClient _httpClient;
+    private ILogger _logger = new NullLogger<AnimeOfflineDatabaseHelperTests>();
     
     private void Setup(List<Helpers.HttpCall> httpCalls) {
         Helpers.MockHttpCalls(httpCalls, ref _httpClient);
@@ -31,7 +34,7 @@ public class AnimeOfflineDatabaseHelperTests {
             }
         });
 
-        AnimeOfflineDatabaseHelpers.OfflineDatabaseResponse? result = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClient, 1, AnimeOfflineDatabaseHelpers.Source.Myanimelist);
+        AnimeOfflineDatabaseHelpers.OfflineDatabaseResponse? result = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClient, _logger, 1, AnimeOfflineDatabaseHelpers.Source.Myanimelist);
         Assert.IsTrue(result != null);
         Assert.IsTrue(result.AniDb == 1);
         Assert.IsTrue(result.Anilist == 1);

--- a/jellyfin-ani-sync/Configuration/ConfigPage.html
+++ b/jellyfin-ani-sync/Configuration/ConfigPage.html
@@ -40,6 +40,11 @@
                     <div id="callbackRedirectUrlDescription" class="fieldDescription"></div>
                 </div>
                 <div class="inputContainer">
+                    <label class="inputLabel inputLabelUnfocused" for="armServerBaseUrlInput">Custom ARM server base URL</label>
+                    <input id="armServerBaseUrlInput" type="text" is="emby-input"/>
+                    <div id="armServerBaseUrlInputDescription" class="fieldDescription">Enter your custom ARM server base URL. This should be the base URL only, e.g. "http://localhost:3000". Will fall back to using the publicly hosted service if unable to parse the URL correctly.</div>
+                </div>
+                <div class="inputContainer">
                     <label class="inputLabel inputLabelUnfocused" for="animeListSaveLocation">Anime List Save
                         Location</label>
                     <input id="animeListSaveLocation" name="animeListSaveLocation" type="text" is="emby-input"/>

--- a/jellyfin-ani-sync/Configuration/ConfigPageJs.js
+++ b/jellyfin-ani-sync/Configuration/ConfigPageJs.js
@@ -314,6 +314,8 @@ async function initialLoad(common) {
 
             if (config.callbackUrl)
                 page.querySelector('#apiUrl').value = config.callbackUrl;
+            if (config.armServerBaseUrl)
+                page.querySelector('#armServerBaseUrlInput').value = config.armServerBaseUrl;
             Dashboard.hideLoadingMsg();
         });
     }
@@ -386,6 +388,7 @@ async function initialLoad(common) {
             config.simklUpdateAll = document.querySelector('#simklUpdateAll').checked;
             config.updateNsfw = document.querySelector('#UpdateNsfw').checked;
             config.authenticationLinkExpireTimeMinutes = document.querySelector('#linkTimeExpire').value;
+            config.armServerBaseUrl = document.querySelector('#armServerBaseUrlInput').value;
 
             userConfig.LibraryToCheck = Array.prototype.map.call(document.querySelectorAll('.library:checked'), element => {
                 return element.getAttribute('id');

--- a/jellyfin-ani-sync/Configuration/PluginConfiguration.cs
+++ b/jellyfin-ani-sync/Configuration/PluginConfiguration.cs
@@ -56,5 +56,10 @@ namespace jellyfin_ani_sync.Configuration {
         /// How long the memory cache holds onto users authentication details in minutes.
         /// </summary>
         public long authenticationLinkExpireTimeMinutes { get; set; }
+        
+        /// <summary>
+        /// Custom ARM server base URL.
+        /// </summary>
+        public string armServerBaseUrl { get; set; }
     }
 }

--- a/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
@@ -5,13 +5,29 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using jellyfin_ani_sync.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace jellyfin_ani_sync.Helpers {
     public class AnimeOfflineDatabaseHelpers {
-        public static async Task<OfflineDatabaseResponse> GetProviderIdsFromMetadataProvider(HttpClient httpClient, int metadataId, Source source) {
+        public static async Task<OfflineDatabaseResponse> GetProviderIdsFromMetadataProvider(HttpClient httpClient, ILogger logger, int metadataId, Source source) {
             // See https://arm.haglund.dev/docs#tag/v2/operation/v2-getIds
-            // TODO: make URL user-configurable to allow self-hosting the server.
-            var response = await httpClient.GetAsync($"https://arm.haglund.dev/api/v2/ids?source={source.ToString().ToLower()}&id={metadataId}");
+            string baseUrl = "https://arm.haglund.dev"; // fallback value, the public API
+            string customArmServerBaseUrl = Plugin.Instance?.Configuration.armServerBaseUrl;
+            if (!string.IsNullOrEmpty(customArmServerBaseUrl)) {
+                if (Uri.TryCreate(customArmServerBaseUrl, UriKind.Absolute, out Uri baseUri) && (baseUri.Scheme == Uri.UriSchemeHttp || baseUri.Scheme == Uri.UriSchemeHttps)) {
+                    baseUrl = baseUri.AbsoluteUri;
+                } else {
+                    logger.LogWarning($"ARM server base URL ({customArmServerBaseUrl}) could not be parsed. Confirm the URL is valid. Falling back to public API...");
+                }
+            }
+
+            HttpResponseMessage response;
+            try {
+                response = await httpClient.GetAsync($"{baseUrl}/api/v2/ids?source={source.ToString().ToLower()}&id={metadataId}");
+            } catch (Exception e) {
+                logger.LogError("Error encountered while retrieving provider IDs: {Message}\n{StackTrace}", e.Message, e.StackTrace);
+                return null;
+            }
             StreamReader streamReader = new StreamReader(await response.Content.ReadAsStreamAsync());
             string streamText = await streamReader.ReadToEndAsync();
 

--- a/jellyfin-ani-sync/Helpers/SyncHelper.cs
+++ b/jellyfin-ani-sync/Helpers/SyncHelper.cs
@@ -100,7 +100,7 @@ public class SyncHelper {
         IHttpClientFactory httpClientFactory,
         IApplicationPaths applicationPaths,
         List<int> seasonFilter = null) {
-        var id = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(httpClientFactory.CreateClient(NamedClient.Default), providerId, source);
+        var id = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(httpClientFactory.CreateClient(NamedClient.Default), logger, providerId, source);
         if (id is { AniDb: { } }) {
             AnimeListHelpers.AnimeListXml animeListXml = await AnimeListHelpers.GetAnimeListFileContents(logger, loggerFactory, httpClientFactory, applicationPaths);
             var seasons = AnimeListHelpers.ListAllSeasonOfAniDbSeries(id.AniDb.Value, animeListXml);

--- a/jellyfin-ani-sync/Sync/Sync.cs
+++ b/jellyfin-ani-sync/Sync/Sync.cs
@@ -218,7 +218,7 @@ public class Sync {
         List<SyncAnimeMetadata> animeIdProgress = new List<SyncAnimeMetadata>();
         for (var i = 0; i < animeList.Count; i++) {
             _logger.LogInformation($"(Sync) Fetching IDs for anime with an ID of {animeList[i].Id}...");
-            var ids = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClientFactory.CreateClient(NamedClient.Default), animeList[i].Id, AnimeOfflineDatabaseHelpers.MapFromApiName(_apiName));
+            var ids = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClientFactory.CreateClient(NamedClient.Default), _logger, animeList[i].Id, AnimeOfflineDatabaseHelpers.MapFromApiName(_apiName));
             if (ids?.AniDb == null) {
                 _logger.LogError("(Sync) Could not retrieve AniDb ID; skipping item...");
                 continue;

--- a/jellyfin-ani-sync/UpdateProviderStatus.cs
+++ b/jellyfin-ani-sync/UpdateProviderStatus.cs
@@ -111,7 +111,7 @@ namespace jellyfin_ani_sync {
                           movie.ProviderIds.ContainsKey("AniList") &&
                           int.TryParse(movie.ProviderIds["AniList"], out retrievedAniListId)) {
                     _logger.LogInformation("AniList ID found. Retrieving provider IDs from offline database...");
-                    _apiIds = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClientFactory.CreateClient(NamedClient.Default), retrievedAniListId, AnimeOfflineDatabaseHelpers.Source.Anilist);
+                    _apiIds = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClientFactory.CreateClient(NamedClient.Default), _logger, retrievedAniListId, AnimeOfflineDatabaseHelpers.Source.Anilist);
                     if (_apiIds is null) {
                         _apiIds = new AnimeOfflineDatabaseHelpers.OfflineDatabaseResponse {
                             Anilist = retrievedAniListId
@@ -132,7 +132,7 @@ namespace jellyfin_ani_sync {
                         : await AnimeListHelpers.GetAniDbId(_logger, movie, movie.IndexNumber.Value, 1, animeListXml);
                     if (aniDbId.aniDbId != null) {
                         _logger.LogInformation($"Retrieving provider IDs from offline database for AniDb ID {aniDbId.aniDbId.Value}...");
-                        _apiIds = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClientFactory.CreateClient(NamedClient.Default), aniDbId.aniDbId.Value, AnimeOfflineDatabaseHelpers.Source.Anidb);
+                        _apiIds = await AnimeOfflineDatabaseHelpers.GetProviderIdsFromMetadataProvider(_httpClientFactory.CreateClient(NamedClient.Default), _logger, aniDbId.aniDbId.Value, AnimeOfflineDatabaseHelpers.Source.Anidb);
                         if (_apiIds is null) {
                             _apiIds = new AnimeOfflineDatabaseHelpers.OfflineDatabaseResponse {
                                 AniDb = aniDbId.aniDbId


### PR DESCRIPTION
This PR allows custom ARM server usage by allowing users to enter a base URL used during the provider ID retrieval process.
This will be going into a beta branch before being merged into master.