### PR TITLE
fix: strip trailing slash from custom ARM base URL

### DIFF
--- a/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
@@ -15,7 +15,7 @@ namespace jellyfin_ani_sync.Helpers {
             string customArmServerBaseUrl = Plugin.Instance?.Configuration.armServerBaseUrl;
             if (!string.IsNullOrEmpty(customArmServerBaseUrl)) {
                 if (Uri.TryCreate(customArmServerBaseUrl, UriKind.Absolute, out Uri baseUri) && (baseUri.Scheme == Uri.UriSchemeHttp || baseUri.Scheme == Uri.UriSchemeHttps)) {
-                    baseUrl = baseUri.AbsoluteUri;
+                    baseUrl = baseUri.AbsoluteUri.TrimEnd('/');
                 } else {
                     logger.LogWarning($"ARM server base URL ({customArmServerBaseUrl}) could not be parsed. Confirm the URL is valid. Falling back to public API...");
                 }


### PR DESCRIPTION
## Summary

With a custom `armServerBaseUrl` set, the plugin sends requests to `http(s)://host//api/v2/ids?...` (double slash). `BeeeQueue/arm-server` returns 404 for that path, so the lookup silently fails and the plugin falls back to title search.

Cause: `Uri.AbsoluteUri` adds a trailing `/` to authority-only URLs, which then concatenates with `/api/v2/ids` into `//api/v2/ids`. The public `arm.haglund.dev` hides this because Cloudflare collapses `//` before the origin sees it.

Fix: trim the trailing slash before concatenation.

## Test plan

- [x] Tested against a local self-hosted `arm-server`.