### PR TITLE
Shoko Server addition, Fix AniDB resolution for sequels, split cours and titlefallbacks

### DIFF
--- a/jellyfin-ani-sync-unit-tests/HelperTests/AnimeListResolutionTests.cs
+++ b/jellyfin-ani-sync-unit-tests/HelperTests/AnimeListResolutionTests.cs
@@ -1,0 +1,155 @@
+using System.Collections.Generic;
+using jellyfin_ani_sync.Helpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace jellyfin_ani_sync_unit_tests.HelperTests;
+
+/// <summary>
+/// Regression tests for AniDB resolution against two real anime-list-full.xml
+/// shapes that previously resolved to the wrong entry.
+///
+/// Both fixtures are trimmed copies of real rows, keeping only the attributes
+/// the resolution logic reads.
+/// </summary>
+public class AnimeListResolutionTests {
+    private readonly ILogger _logger = new NullLogger<AnimeListResolutionTests>();
+
+    /// <summary>
+    /// Bleach, TVDB 74796. Nine AniDB entries share this TVDB ID; only the
+    /// original 366-episode series carries a mapping-list, and all four
+    /// Sennen Kessen Hen entries carry none. Sennen Kessen Hen is TVDB
+    /// season 17, not season 2.
+    /// </summary>
+    private static List<AnimeListHelpers.AnimeListAnime> BleachRows() => new() {
+        // The original series. First in document order, and the only row with
+        // start/end mappings - which is what made it win every lookup.
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "2369",
+            Tvdbid = "74796",
+            Defaulttvdbseason = "a",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    // No start/end in the XML. Start and End are non-nullable
+                    // ints, so they default to 0 rather than being absent.
+                    new() { Anidbseason = 0, Tvdbseason = 0 },
+                    new() { Anidbseason = 1, Tvdbseason = 1, Start = 1, End = 20, Offset = 0 },
+                    new() { Anidbseason = 1, Tvdbseason = 2, Start = 21, End = 41, Offset = -20 }
+                }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "15449", Tvdbid = "74796", Defaulttvdbseason = "17" },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "17765", Tvdbid = "74796", Defaulttvdbseason = "17", Episodeoffset = "13" },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "18220", Tvdbid = "74796", Defaulttvdbseason = "17", Episodeoffset = "26" },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "19079", Tvdbid = "74796", Defaulttvdbseason = "17", Episodeoffset = "40" }
+    };
+
+    /// <summary>
+    /// Mushoku Tensei, TVDB 371310. TVDB season 2 is split across two AniDB
+    /// entries, the second starting after episode 12.
+    /// </summary>
+    private static List<AnimeListHelpers.AnimeListAnime> MushokuRows() => new() {
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "14758", Tvdbid = "371310", Defaulttvdbseason = "1" },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "15954", Tvdbid = "371310", Defaulttvdbseason = "1", Episodeoffset = "11",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    new() { Anidbseason = 0, Tvdbseason = 0, Start = 2, End = 17, Offset = -17 }
+                }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "17236", Tvdbid = "371310", Defaulttvdbseason = "2",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    new() { Anidbseason = 0, Tvdbseason = 0 }
+                }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "18104", Tvdbid = "371310", Defaulttvdbseason = "2", Episodeoffset = "12" },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "18727", Tvdbid = "371310", Defaulttvdbseason = "3" }
+    };
+
+    /// <summary>
+    /// The original defect. Matching an absolute episode number against
+    /// mapping start/end without also comparing the season meant the first row
+    /// owning a mapping table always won. Absolute episode 41 falls inside
+    /// 2369's TVDB season 2 range of 21-41, so a lookup for TVDB season 17
+    /// returned the original Bleach series.
+    /// </summary>
+    [Test]
+    public void AbsoluteEpisodeLookup_DoesNotCollapseSequelOntoParentSeries() {
+        var returned = AnimeListHelpers.GetAniDbByEpisodeOffset(
+            _logger, absoluteEpisodeNumber: 41, seasonNumber: 17, episodeNumber: 41, related: BleachRows());
+
+        Assert.IsTrue(returned.aniDbId != 2369, "Sequel season resolved to the parent series");
+        Assert.IsTrue(returned.aniDbId == 19079);
+        Assert.IsTrue(returned.episodeOffset == 40);
+    }
+
+    /// <summary>
+    /// Positive control for the test above. The same absolute episode number,
+    /// looked up against the season it genuinely belongs to, must still resolve
+    /// through the mapping table. This proves the season comparison is what
+    /// changed the earlier result, rather than the absolute-episode path having
+    /// been disabled outright.
+    /// </summary>
+    [Test]
+    public void AbsoluteEpisodeLookup_StillMatchesWithinTheCorrectSeason() {
+        var returned = AnimeListHelpers.GetAniDbByEpisodeOffset(
+            _logger, absoluteEpisodeNumber: 41, seasonNumber: 2, episodeNumber: 41, related: BleachRows());
+
+        Assert.IsTrue(returned.aniDbId == 2369);
+        Assert.IsTrue(returned.episodeOffset == -20, "The mapping's offset must be returned, not null");
+    }
+
+    /// <summary>
+    /// Each Sennen Kessen Hen cour must be selected by its episode offset
+    /// within TVDB season 17.
+    /// </summary>
+    [Test]
+    public void SeasonLookup_SelectsCorrectCourWithinSeason17() {
+        var rows = BleachRows();
+
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 17, 1, rows).aniDbId == 15449);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 17, 14, rows).aniDbId == 17765);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 17, 27, rows).aniDbId == 18220);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 17, 41, rows).aniDbId == 19079);
+    }
+
+    /// <summary>
+    /// A split cour. TVDB season 2 episodes 1-12 belong to 17236; episode 13
+    /// onwards belong to 18104 and must be renumbered by its offset of 12.
+    /// This is the shape produced by Shokofin season merging, where one
+    /// Jellyfin season contains both AniDB series numbered continuously.
+    /// </summary>
+    [Test]
+    public void SeasonLookup_SplitCourSelectsCorrectPartAndOffset() {
+        var rows = MushokuRows();
+
+        var firstCour = AnimeListHelpers.SeasonLookup(_logger, 2, 6, rows);
+        Assert.IsTrue(firstCour.aniDbId == 17236);
+        Assert.IsTrue(firstCour.episodeOffset == null || firstCour.episodeOffset == 0);
+
+        var boundary = AnimeListHelpers.SeasonLookup(_logger, 2, 13, rows);
+        Assert.IsTrue(boundary.aniDbId == 18104);
+        Assert.IsTrue(boundary.episodeOffset == 12);
+        Assert.IsTrue(13 - boundary.episodeOffset == 1, "First episode of the second cour must map to episode 1");
+
+        var lastEpisode = AnimeListHelpers.SeasonLookup(_logger, 2, 24, rows);
+        Assert.IsTrue(lastEpisode.aniDbId == 18104);
+        Assert.IsTrue(24 - lastEpisode.episodeOffset == 12);
+    }
+
+    /// <summary>
+    /// The split cour must not leak into neighbouring seasons.
+    /// </summary>
+    [Test]
+    public void SeasonLookup_DoesNotCrossSeasonBoundaries() {
+        var rows = MushokuRows();
+
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 1, 6, rows).aniDbId == 14758);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 3, 6, rows).aniDbId == 18727);
+    }
+}

--- a/jellyfin-ani-sync-unit-tests/HelperTests/AnimeListResolutionTests.cs
+++ b/jellyfin-ani-sync-unit-tests/HelperTests/AnimeListResolutionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using jellyfin_ani_sync.Helpers;
 using Microsoft.Extensions.Logging;
@@ -194,5 +195,102 @@ public class AnimeListResolutionTests {
 
         Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 1, 6, rows).aniDbId == 14758);
         Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 3, 6, rows).aniDbId == 18727);
+    }
+
+    /// <summary>
+    /// Monogatari, TVDB 102261. Twelve AniDB entries share this TVDB ID: six
+    /// sit on TVDB season 0, and the remaining six each own one sequential
+    /// season. Trimmed copies of real anime-list-full.xml rows.
+    ///
+    /// This is the shape a Shokofin library produces for a long-running
+    /// franchise, where every arc is its own AniDB series but they all share
+    /// one TVDB entry. Selecting the wrong row here silently syncs progress
+    /// against a different arc.
+    /// </summary>
+    private static List<AnimeListHelpers.AnimeListAnime> MonogatariRows() => new() {
+        // Season 0 rows. Six of them, all competing for the same TVDB season.
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "8357", Tvdbid = "102261", Defaulttvdbseason = "0",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> { new() { Anidbseason = 0, Tvdbseason = 0 } }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "9453", Tvdbid = "102261", Defaulttvdbseason = "0",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> { new() { Anidbseason = 0, Tvdbseason = 0 } }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "11827", Tvdbid = "102261", Defaulttvdbseason = "0", Episodeoffset = "20"
+        },
+
+        // One AniDB series per sequential TVDB season.
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "6327", Tvdbid = "102261", Defaulttvdbseason = "1",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    new() { Anidbseason = 0, Tvdbseason = 0 },
+                    new() { Anidbseason = 0, Tvdbseason = 1 }
+                }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "8658", Tvdbid = "102261", Defaulttvdbseason = "2" },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "9183", Tvdbid = "102261", Defaulttvdbseason = "3",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    new() { Anidbseason = 0, Tvdbseason = 0 },
+                    new() { Anidbseason = 0, Tvdbseason = 3 }
+                }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "11350", Tvdbid = "102261", Defaulttvdbseason = "4",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> { new() { Anidbseason = 0, Tvdbseason = 4 } }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "13033", Tvdbid = "102261", Defaulttvdbseason = "5",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    new() { Anidbseason = 0, Tvdbseason = 5 },
+                    new() { Anidbseason = 1, Tvdbseason = 5 }
+                }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime { Anidbid = "18424", Tvdbid = "102261", Defaulttvdbseason = "6" }
+    };
+
+    /// <summary>
+    /// Each sequential season must resolve to its own AniDB series rather than
+    /// collapsing onto whichever row happens to be first in document order.
+    /// </summary>
+    [Test]
+    public void SeasonLookup_MonogatariResolvesEachSeasonToItsOwnSeries() {
+        var rows = MonogatariRows();
+
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 1, 1, rows).aniDbId == 6327);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 2, 1, rows).aniDbId == 8658);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 3, 1, rows).aniDbId == 9183);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 4, 1, rows).aniDbId == 11350);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 5, 1, rows).aniDbId == 13033);
+        Assert.IsTrue(AnimeListHelpers.SeasonLookup(_logger, 6, 1, rows).aniDbId == 18424);
+    }
+
+    /// <summary>
+    /// The six TVDB season 0 rows must not be selected for a numbered season.
+    /// </summary>
+    [Test]
+    public void SeasonLookup_MonogatariSeasonZeroRowsDoNotLeak() {
+        var rows = MonogatariRows();
+        int[] seasonZeroIds = { 8357, 9453, 11827 };
+
+        foreach (var season in new[] { 1, 2, 3, 4, 5, 6 }) {
+            var returned = AnimeListHelpers.SeasonLookup(_logger, season, 1, rows);
+            Assert.IsFalse(Array.Exists(seasonZeroIds, id => id == returned.aniDbId),
+                $"TVDB season {season} resolved to a season 0 row ({returned.aniDbId})");
+        }
     }
 }

--- a/jellyfin-ani-sync-unit-tests/HelperTests/AnimeListResolutionTests.cs
+++ b/jellyfin-ani-sync-unit-tests/HelperTests/AnimeListResolutionTests.cs
@@ -46,6 +46,49 @@ public class AnimeListResolutionTests {
     };
 
     /// <summary>
+    /// Returns a fake split cour with 2 anidb entries for absolute episode ranges that are in the same TVDB season,
+    /// which should trigger the SeasonLookup's "Defaulttvdbseason == a" fallback.
+    /// </summary>
+    private static List<AnimeListHelpers.AnimeListAnime> SplitCourRows() => new() {
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "301",
+            Tvdbid = "500",
+            Defaulttvdbseason = "a",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    new() { Anidbseason = 1, Tvdbseason = 2, Start = 21, End = 30, Offset = -20 }
+                }
+            }
+        },
+        new AnimeListHelpers.AnimeListAnime {
+            Anidbid = "302",
+            Tvdbid = "500",
+            Defaulttvdbseason = "a",
+            MappingList = new AnimeListHelpers.MappingList {
+                Mapping = new List<AnimeListHelpers.Mapping> {
+                    new() { Anidbseason = 1, Tvdbseason = 2, Start = 31, End = 41, Offset = -30 }
+                }
+            }
+        }
+    };
+
+    /// <summary>
+    /// Absolute episode = 35;
+    /// Should be contained in AniDb 302 range as its between 31-41.
+    /// Fixes the issue of subtracting the mappings own offset before
+    /// the comparison takes place (which would cause a fall back to
+    /// SeasonLookup, which we want to try to prevent).
+    /// </summary>
+    [Test]
+    public void AbsoluteEpisodeLookup_DoesNotSubtractOffsetBeforeRangeCheck() {
+        var returned = AnimeListHelpers.GetAniDbByEpisodeOffset(
+            _logger, absoluteEpisodeNumber: 35, seasonNumber: 2, episodeNumber: 5, related: SplitCourRows());
+
+        Assert.IsTrue(returned.aniDbId == 302);
+        Assert.IsTrue(returned.episodeOffset == -30);
+    }
+
+    /// <summary>
     /// Mushoku Tensei, TVDB 371310. TVDB season 2 is split across two AniDB
     /// entries, the second starting after episode 12.
     /// </summary>

--- a/jellyfin-ani-sync/Helpers/AnimeListHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeListHelpers.cs
@@ -94,7 +94,7 @@ namespace jellyfin_ani_sync.Helpers {
                     var seasonRow = animeListXml.Anime.FirstOrDefault(a => a.Anidbid == seasonAniDbId.ToString());
                     if (seasonRow != null && int.TryParse(seasonRow.Defaulttvdbseason, out int tvdbSeason)) {
                         var relatedRows = animeListXml.Anime.Where(a => a.Tvdbid == seasonRow.Tvdbid).ToList();
-                        var resolved = SeasonLookup(logger, tvdbSeason, episodeNumber, relatedRows);
+                        var resolved = GetAniDbByEpisodeOffset(logger, GetAbsoluteEpisodeNumber(episodeWithSeasonAniDbId), tvdbSeason, episodeNumber, relatedRows);
                         if (resolved.aniDbId != null) {
                             logger.LogInformation($"(Anidb) Merged season resolved to AniDb ID {resolved.aniDbId} with offset {(resolved.episodeOffset.HasValue ? resolved.episodeOffset.Value.ToString() : "<none>")} (tvdb season {tvdbSeason})");
                             return resolved;
@@ -236,6 +236,12 @@ namespace jellyfin_ani_sync.Helpers {
                 // sequel entries, which carry no <mapping-list> at all, could never
                 // be selected. Require a genuine range in the correct TVDB season,
                 // and return that mapping's offset rather than null.
+                //
+                // Start/End are AniDB episode numbers while absoluteEpisodeNumber is
+                // in TVDB numbering, so the mapping's own offset has to be removed
+                // before comparing - exactly as SeasonLookup() already does in its
+                // specificMapping predicate. Without it the two functions disagree at
+                // a cour boundary whenever the offset is non-zero.
                 // -----------------------------------------------------------------
                 AnimeListAnime foundMapping = null;
                 Mapping foundRange = null;
@@ -243,8 +249,8 @@ namespace jellyfin_ani_sync.Helpers {
                     var match = animeListAnime.MappingList?.Mapping?.FirstOrDefault(mapping =>
                         mapping.Tvdbseason == seasonNumber &&
                         mapping.Start > 0 && mapping.End > 0 &&
-                        mapping.Start <= absoluteEpisodeNumber &&
-                        mapping.End >= absoluteEpisodeNumber);
+                        absoluteEpisodeNumber - mapping.Offset >= mapping.Start &&
+                        absoluteEpisodeNumber - mapping.Offset <= mapping.End);
                     if (match != null) {
                         foundMapping = animeListAnime;
                         foundRange = match;

--- a/jellyfin-ani-sync/Helpers/AnimeListHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeListHelpers.cs
@@ -50,6 +50,7 @@ namespace jellyfin_ani_sync.Helpers {
         /// <returns></returns>
         public static async Task<(int? aniDbId, int? episodeOffset)> GetAniDbId(ILogger logger, Video video, int episodeNumber, int seasonNumber, AnimeListXml animeListXml) {
             int aniDbId;
+            string aniDbKey = "Anidb";
 
             // ---------------------------------------------------------------------
             // FIX 1: if the season already carries its own AniDB ID, trust it.
@@ -63,7 +64,7 @@ namespace jellyfin_ani_sync.Helpers {
             // applies an offset that does not belong to AniDB numbering.
             // ---------------------------------------------------------------------
             if (video is Episode episodeWithSeasonAniDbId &&
-                TryGetProviderId(episodeWithSeasonAniDbId.Season?.ProviderIds, "Anidb", out var seasonAniDbIdRaw) &&
+                TryGetProviderId(episodeWithSeasonAniDbId.Season?.ProviderIds, aniDbKey, out var seasonAniDbIdRaw) &&
                 int.TryParse(seasonAniDbIdRaw, out var seasonAniDbId)) {
                 // -----------------------------------------------------------------
                 // FIX 10: fix 1's premise is "one Jellyfin season == one AniDB series".
@@ -77,15 +78,25 @@ namespace jellyfin_ani_sync.Helpers {
                 // -----------------------------------------------------------------
                 bool haveSeasonShoko = TryGetProviderId(episodeWithSeasonAniDbId.Season?.ProviderIds, "Shoko Series", out var seasonShokoSeries);
                 bool haveEpisodeShoko = TryGetProviderId(episodeWithSeasonAniDbId.ProviderIds, "Shoko Series", out var episodeShokoSeries);
-                bool mergedSeason = haveSeasonShoko && haveEpisodeShoko &&
-                                    !string.Equals(seasonShokoSeries, episodeShokoSeries, StringComparison.OrdinalIgnoreCase);
+
+                bool mergedSeason;
+                if (!haveEpisodeShoko) {
+                    // No Shoko-assigned series on the episode so could be from a non-shoko provider. We can't be sure its merged.
+                    mergedSeason = false;
+                } else if (!haveSeasonShoko) {
+                    // Episode level shoko tag but no season level tag; not entirely sure how this can happen but we should treat this as a merge just to be safe
+                    logger.LogWarning($"({aniDbKey}) Season {seasonNumber} has no 'Shoko Series' tag but episode {episodeShokoSeries} does; cannot confirm whether the season is merged, treating it as merged just to be safe");
+                    mergedSeason = true;
+                } else {
+                    mergedSeason = !string.Equals(seasonShokoSeries, episodeShokoSeries, StringComparison.OrdinalIgnoreCase);
+                }
 
                 if (!mergedSeason) {
-                    logger.LogInformation($"(Anidb) Season {seasonNumber} carries its own AniDb ID ({seasonAniDbId}); using it directly with no episode offset");
+                    logger.LogInformation($"({aniDbKey}) Season {seasonNumber} carries its own {aniDbKey} ID ({seasonAniDbId}); using it directly with no episode offset");
                     return (seasonAniDbId, null);
                 }
 
-                logger.LogInformation($"(Anidb) Season {seasonNumber} is merged (season Shoko Series {seasonShokoSeries}, episode Shoko Series {episodeShokoSeries}); resolving the correct entry from the anime list XML");
+                logger.LogInformation($"({aniDbKey}) Season {seasonNumber} is merged (season Shoko Series {seasonShokoSeries}, episode Shoko Series {episodeShokoSeries}); resolving the correct entry from the anime list XML");
 
                 if (animeListXml?.Anime != null) {
                     // Derive the TVDB season from the season's own AniDB row rather than
@@ -96,36 +107,38 @@ namespace jellyfin_ani_sync.Helpers {
                         var relatedRows = animeListXml.Anime.Where(a => a.Tvdbid == seasonRow.Tvdbid).ToList();
                         var resolved = GetAniDbByEpisodeOffset(logger, GetAbsoluteEpisodeNumber(episodeWithSeasonAniDbId), tvdbSeason, episodeNumber, relatedRows);
                         if (resolved.aniDbId != null) {
-                            logger.LogInformation($"(Anidb) Merged season resolved to AniDb ID {resolved.aniDbId} with offset {(resolved.episodeOffset.HasValue ? resolved.episodeOffset.Value.ToString() : "<none>")} (tvdb season {tvdbSeason})");
+                            logger.LogInformation($"({aniDbKey}) Merged season resolved to AniDb ID {resolved.aniDbId} with offset {(resolved.episodeOffset.HasValue ? resolved.episodeOffset.Value.ToString() : "<none>")} (tvdb season {tvdbSeason})");
                             return resolved;
                         }
                     } else {
-                        logger.LogWarning($"(Anidb) AniDb ID {seasonAniDbId} has no usable anime list XML row; cannot resolve merged season");
+                        logger.LogWarning($"({aniDbKey}) {aniDbKey} ID {seasonAniDbId} has no usable anime list XML row; cannot resolve merged season");
                     }
                 }
 
-                logger.LogWarning($"(Anidb) Could not resolve merged season from the XML; falling back to the season AniDb ID ({seasonAniDbId}). Episode numbers past the first merged part will be wrong.");
+                logger.LogWarning($"({aniDbKey}) Could not resolve merged season from the XML; falling back to the season {aniDbKey} ID ({seasonAniDbId}). Episode numbers past the first merged part will be wrong.");
                 return (seasonAniDbId, null);
             }
 
             if (animeListXml == null) return (null, null);
             Dictionary<string, string> providers;
-            if (video is Episode) {
-                //Search for Anidb id at season level
-                providers = (video as Episode).Season.ProviderIds.ContainsKey("Anidb") ? (video as Episode).Season.ProviderIds : (video as Episode).Series.ProviderIds;
-            } else if (video is Movie) {
-                providers = (video as Movie).ProviderIds;
-            } else {
-                return (null, null);
+            {
+                if (video is Episode episode) {
+                    //Search for Anidb id at season level
+                    providers = HasProviderId(episode.Season.ProviderIds, aniDbKey) ? episode.Season.ProviderIds : episode.Series.ProviderIds;
+                } else if (video is Movie movie) {
+                    providers = movie.ProviderIds;
+                } else {
+                    return (null, null);
+                }
             }
 
-            if (providers.ContainsKey("Anidb")) {
-                logger.LogInformation("(Anidb) Anime already has AniDb ID; no need to look it up");
-                if (!int.TryParse(providers["Anidb"], out aniDbId)) return (null, null);
+            if (TryGetProviderId(providers, aniDbKey, out string aniDbProviderId)) {
+                logger.LogInformation($"({aniDbKey}) Anime already has AniDb ID; no need to look it up");
+                if (!int.TryParse(aniDbProviderId, out aniDbId)) return (null, null);
                 var foundAnime = animeListXml.Anime.Where(anime => int.TryParse(anime.Anidbid, out int xmlAniDbId) &&
                                                                    xmlAniDbId == aniDbId &&
                                                                    (
-                                                                       (video as Episode).Season.ProviderIds.ContainsKey("Anidb") ||
+                                                                       (video is Episode episode && HasProviderId(episode.Season?.ProviderIds, aniDbKey)) ||
                                                                        (int.TryParse(anime.Defaulttvdbseason, out int xmlSeason) &&
                                                                         xmlSeason == seasonNumber ||
                                                                         anime.Defaulttvdbseason == "a")
@@ -136,58 +149,57 @@ namespace jellyfin_ani_sync.Helpers {
                         var related = animeListXml.Anime.Where(anime => anime.Tvdbid == foundAnime.First().Tvdbid).ToList();
                         if (video is Episode episode && episode.Series.Children.OfType<Season>().Count() > 1 && related.Count > 1) {
                             // contains more than 1 season, need to do a lookup
-                            logger.LogInformation($"(Anidb) Anime {episode.Series.Name} found in anime XML file");
-                            logger.LogInformation($"(Anidb) Looking up anime {episode.Series.Name} in the anime XML file by absolute episode number...");
+                            logger.LogInformation($"({aniDbKey}) Anime {episode.Series.Name} found in anime XML file");
+                            logger.LogInformation($"({aniDbKey}) Looking up anime {episode.Series.Name} in the anime XML file by absolute episode number...");
                             var (aniDb, episodeOffset) = GetAniDbByEpisodeOffset(logger, GetAbsoluteEpisodeNumber(episode), seasonNumber, episodeNumber, related);
                             if (aniDb != null) {
-                                logger.LogInformation($"(Anidb) Anime {episode.Series.Name} found in anime XML file, detected AniDB ID {aniDb}");
+                                logger.LogInformation($"({aniDbKey}) Anime {episode.Series.Name} found in anime XML file, detected AniDB ID {aniDb}");
                                 return (aniDb, episodeOffset);
                             } else {
-                                logger.LogInformation($"(Anidb) Anime {episode.Series.Name} could not found in anime XML file; falling back to other metadata providers if available...");
+                                logger.LogInformation($"({aniDbKey}) Anime {episode.Series.Name} could not found in anime XML file; falling back to other metadata providers if available...");
                             }
                         } else {
                             if (video is Episode episodeWithMultipleSeasons && episodeWithMultipleSeasons.Season.IndexNumber > 1) {
                                 // user doesnt have full series; have to do season lookup
-                                logger.LogInformation($"(Anidb) Anime {episodeWithMultipleSeasons.Series.Name} found in anime XML file");
+                                logger.LogInformation($"({aniDbKey}) Anime {episodeWithMultipleSeasons.Series.Name} found in anime XML file");
                                 return SeasonLookup(logger, seasonNumber, episodeNumber, related);
                             } else {
-                                logger.LogInformation($"(Anidb) Anime {video.Name} found in anime XML file");
+                                logger.LogInformation($"({aniDbKey}) Anime {video.Name} found in anime XML file");
                                 // is movie / only has one season / no related; just return the only result
                                 return int.TryParse(related.First().Anidbid, out aniDbId) ? (aniDbId, null) : (null, null);
                             }
-
-                            logger.LogInformation($"(Anidb) Anime {(video is Episode episodeWithoutSeason ? episodeWithoutSeason.Name : video.Name)} found in anime XML file");
-                            // is movie / only has one season / no related; just return the only result
-                            return int.TryParse(foundAnime.First().Anidbid, out aniDbId) ? (aniDbId, null) : (null, null);
                         }
 
                         break;
                     case > 1:
                         // here
-                        logger.LogWarning("(Anidb) More than one result found; possibly an issue with the XML. Falling back to other metadata providers if available...");
+                        logger.LogWarning($"({aniDbKey}) More than one result found; possibly an issue with the XML. Falling back to other metadata providers if available...");
                         break;
                     case 0:
-                        logger.LogWarning("(Anidb) Anime not found in anime list XML; falling back to other metadata providers if available...");
+                        logger.LogWarning($"({aniDbKey}) Anime not found in anime list XML; falling back to other metadata providers if available...");
                         break;
                 }
             }
 
             //Search for tvdb id at series level
-            if (video is Episode) {
-                providers = (video as Episode).Series.ProviderIds;
+            {
+                if (video is Episode episode) {
+                    providers = episode.Series.ProviderIds;
+                }
             }
 
-            if (providers.ContainsKey("Tvdb")) {
-                int tvDbId;
-                if (!int.TryParse(providers["Tvdb"], out tvDbId)) return (null, null);
+            string tvDbKey = "Tvdb";
+
+            if (TryGetProviderId(providers, tvDbKey, out string tvDbProviderId)) {
+                if (!int.TryParse(tvDbProviderId, out var tvDbId)) return (null, null);
                 var related = animeListXml.Anime.Where(anime => int.TryParse(anime.Tvdbid, out int xmlTvDbId) && xmlTvDbId == tvDbId).ToList();
 
                 if (!related.Any()) {
-                    logger.LogWarning("(Tvdb) Anime not found in anime list XML; querying the appropriate providers API");
+                    logger.LogWarning($"({tvDbKey}) Anime not found in anime list XML; querying the appropriate providers API");
                     return (null, null);
                 }
 
-                logger.LogInformation("(Tvdb) Anime reference found in anime list XML");
+                logger.LogInformation($"({tvDbKey}) Anime reference found in anime list XML");
 
                 var first = related.First();
                 if (related.Count() == 1) {
@@ -200,18 +212,18 @@ namespace jellyfin_ani_sync.Helpers {
                 if (video is Episode episode && episode.Series.Children.OfType<Season>().Count() > 1) {
                     var (aniDb, episodeOffset) = GetAniDbByEpisodeOffset(logger, GetAbsoluteEpisodeNumber(episode), seasonNumber, episodeNumber, related);
                     if (aniDb != null) {
-                        logger.LogInformation($"(Tvdb) Anime {episode.Series.Name} found in anime XML file, detected AniDB ID {aniDb}");
+                        logger.LogInformation($"({tvDbKey}) Anime {episode.Series.Name} found in anime XML file, detected AniDB ID {aniDb}");
                         return (aniDb.Value, episodeOffset);
                     } else {
-                        logger.LogInformation($"(Tvdb) Anime {episode.Series.Name} could not found in anime XML file; falling back to other metadata providers if available...");
+                        logger.LogInformation($"({tvDbKey}) Anime {episode.Series.Name} could not found in anime XML file; falling back to other metadata providers if available...");
                     }
                 } else {
                     if (video is Episode episodeWithMultipleSeasons && episodeWithMultipleSeasons.Season.IndexNumber > 1) {
                         // user doesnt have full series; have to do season lookup
-                        logger.LogInformation($"(Tvdb) Anime {episodeWithMultipleSeasons.Name} found in anime XML file");
+                        logger.LogInformation($"({tvDbKey}) Anime {episodeWithMultipleSeasons.Name} found in anime XML file");
                         return SeasonLookup(logger, seasonNumber, episodeNumber, related);
                     } else {
-                        logger.LogInformation($"(Tvdb) Anime {video.Name} found in anime XML file");
+                        logger.LogInformation($"({tvDbKey}) Anime {video.Name} found in anime XML file");
                         // is movie / only has one season / no related; just return the only result
                         return (
                             int.TryParse(first.Anidbid, out aniDbId) ? aniDbId : null,
@@ -237,11 +249,8 @@ namespace jellyfin_ani_sync.Helpers {
                 // be selected. Require a genuine range in the correct TVDB season,
                 // and return that mapping's offset rather than null.
                 //
-                // Start/End are AniDB episode numbers while absoluteEpisodeNumber is
-                // in TVDB numbering, so the mapping's own offset has to be removed
-                // before comparing - exactly as SeasonLookup() already does in its
-                // specificMapping predicate. Without it the two functions disagree at
-                // a cour boundary whenever the offset is non-zero.
+                // No need to remove offset here from absoluteEpisodeNumber as its
+                // already cumulative (absolute).
                 // -----------------------------------------------------------------
                 AnimeListAnime foundMapping = null;
                 Mapping foundRange = null;
@@ -249,8 +258,8 @@ namespace jellyfin_ani_sync.Helpers {
                     var match = animeListAnime.MappingList?.Mapping?.FirstOrDefault(mapping =>
                         mapping.Tvdbseason == seasonNumber &&
                         mapping.Start > 0 && mapping.End > 0 &&
-                        absoluteEpisodeNumber - mapping.Offset >= mapping.Start &&
-                        absoluteEpisodeNumber - mapping.Offset <= mapping.End);
+                        absoluteEpisodeNumber >= mapping.Start &&
+                        absoluteEpisodeNumber <= mapping.End);
                     if (match != null) {
                         foundMapping = animeListAnime;
                         foundRange = match;
@@ -324,7 +333,7 @@ namespace jellyfin_ani_sync.Helpers {
         }
 
         private static int? GetAbsoluteEpisodeNumber(Episode episode) {
-            var previousSeasons = episode.Series.Children.OfType<Season>().Where(item => item.IndexNumber < episode.Season.IndexNumber).ToList();
+            var previousSeasons = episode.Series.Children.OfType<Season>().Where(item => item.IndexNumber > 0 && item.IndexNumber < episode.Season.IndexNumber).ToList();
             int previousSeasonIndexNumber = -1;
             foreach (int indexNumber in previousSeasons.Where(item => item.IndexNumber != null).Select(item => item.IndexNumber).OrderBy(item => item.Value)) {
                 if (previousSeasonIndexNumber == -1) {

--- a/jellyfin-ani-sync/Helpers/AnimeListHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeListHelpers.cs
@@ -14,6 +14,33 @@ using Microsoft.Extensions.Logging;
 namespace jellyfin_ani_sync.Helpers {
     public class AnimeListHelpers {
         /// <summary>
+        /// Look up a provider ID without caring about key casing.
+        ///
+        /// Jellyfin's ProviderIds dictionary is NOT reliably case-insensitive once an
+        /// item has been round-tripped through the database, and metadata providers
+        /// disagree about spelling: Shokofin writes "AniDB", while this plugin
+        /// historically looked for "Anidb". The result was that every AniDB ID in a
+        /// Shoko-backed library was invisible to the plugin, silently falling through
+        /// to the TVDB code path.
+        /// </summary>
+        public static bool TryGetProviderId(Dictionary<string, string> providerIds, string key, out string value) {
+            value = null;
+            if (providerIds == null) return false;
+            foreach (var providerId in providerIds) {
+                if (string.Equals(providerId.Key, key, StringComparison.OrdinalIgnoreCase)) {
+                    value = providerId.Value;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool HasProviderId(Dictionary<string, string> providerIds, string key) {
+            return TryGetProviderId(providerIds, key, out _);
+        }
+
+        /// <summary>
         /// Get the AniDb ID from the set of providers provided.
         /// </summary>
         /// <param name="logger">Logger.</param>
@@ -23,6 +50,64 @@ namespace jellyfin_ani_sync.Helpers {
         /// <returns></returns>
         public static async Task<(int? aniDbId, int? episodeOffset)> GetAniDbId(ILogger logger, Video video, int episodeNumber, int seasonNumber, AnimeListXml animeListXml) {
             int aniDbId;
+
+            // ---------------------------------------------------------------------
+            // FIX 1: if the season already carries its own AniDB ID, trust it.
+            //
+            // Metadata providers such as Shokofin assign a distinct AniDB series ID
+            // to every season and number that season's episodes 1..N relative to
+            // that AniDB series. In that situation the anime-list XML lookup below
+            // is not merely redundant, it is actively harmful: the XML's season
+            // numbers and episodeoffset values are expressed in TVDB terms, so
+            // re-deriving the ID collapses sequels back onto the parent series and
+            // applies an offset that does not belong to AniDB numbering.
+            // ---------------------------------------------------------------------
+            if (video is Episode episodeWithSeasonAniDbId &&
+                TryGetProviderId(episodeWithSeasonAniDbId.Season?.ProviderIds, "Anidb", out var seasonAniDbIdRaw) &&
+                int.TryParse(seasonAniDbIdRaw, out var seasonAniDbId)) {
+                // -----------------------------------------------------------------
+                // FIX 10: fix 1's premise is "one Jellyfin season == one AniDB series".
+                // Shokofin's season merging breaks that premise: several AniDB series
+                // are folded into a single season with continuous 1..N numbering, and
+                // the season-level AniDB ID then describes only the FIRST of them.
+                //
+                // Shoko tags every episode with the series it really belongs to, so a
+                // mismatch between the episode's "Shoko Series" and the season's is a
+                // reliable, purely local signal that this season is merged.
+                // -----------------------------------------------------------------
+                bool haveSeasonShoko = TryGetProviderId(episodeWithSeasonAniDbId.Season?.ProviderIds, "Shoko Series", out var seasonShokoSeries);
+                bool haveEpisodeShoko = TryGetProviderId(episodeWithSeasonAniDbId.ProviderIds, "Shoko Series", out var episodeShokoSeries);
+                bool mergedSeason = haveSeasonShoko && haveEpisodeShoko &&
+                                    !string.Equals(seasonShokoSeries, episodeShokoSeries, StringComparison.OrdinalIgnoreCase);
+
+                if (!mergedSeason) {
+                    logger.LogInformation($"(Anidb) Season {seasonNumber} carries its own AniDb ID ({seasonAniDbId}); using it directly with no episode offset");
+                    return (seasonAniDbId, null);
+                }
+
+                logger.LogInformation($"(Anidb) Season {seasonNumber} is merged (season Shoko Series {seasonShokoSeries}, episode Shoko Series {episodeShokoSeries}); resolving the correct entry from the anime list XML");
+
+                if (animeListXml?.Anime != null) {
+                    // Derive the TVDB season from the season's own AniDB row rather than
+                    // from Jellyfin's season index; the two disagree whenever the metadata
+                    // provider does not number seasons the way TVDB does.
+                    var seasonRow = animeListXml.Anime.FirstOrDefault(a => a.Anidbid == seasonAniDbId.ToString());
+                    if (seasonRow != null && int.TryParse(seasonRow.Defaulttvdbseason, out int tvdbSeason)) {
+                        var relatedRows = animeListXml.Anime.Where(a => a.Tvdbid == seasonRow.Tvdbid).ToList();
+                        var resolved = SeasonLookup(logger, tvdbSeason, episodeNumber, relatedRows);
+                        if (resolved.aniDbId != null) {
+                            logger.LogInformation($"(Anidb) Merged season resolved to AniDb ID {resolved.aniDbId} with offset {(resolved.episodeOffset.HasValue ? resolved.episodeOffset.Value.ToString() : "<none>")} (tvdb season {tvdbSeason})");
+                            return resolved;
+                        }
+                    } else {
+                        logger.LogWarning($"(Anidb) AniDb ID {seasonAniDbId} has no usable anime list XML row; cannot resolve merged season");
+                    }
+                }
+
+                logger.LogWarning($"(Anidb) Could not resolve merged season from the XML; falling back to the season AniDb ID ({seasonAniDbId}). Episode numbers past the first merged part will be wrong.");
+                return (seasonAniDbId, null);
+            }
+
             if (animeListXml == null) return (null, null);
             Dictionary<string, string> providers;
             if (video is Episode) {
@@ -139,15 +224,39 @@ namespace jellyfin_ani_sync.Helpers {
             return (null, null);
         }
 
-        private static (int? aniDbId, int? episodeOffset) GetAniDbByEpisodeOffset(ILogger logger, int? absoluteEpisodeNumber, int seasonNumber, int episodeNumber, List<AnimeListAnime> related) {
+        internal static (int? aniDbId, int? episodeOffset) GetAniDbByEpisodeOffset(ILogger logger, int? absoluteEpisodeNumber, int seasonNumber, int episodeNumber, List<AnimeListAnime> related) {
             if (absoluteEpisodeNumber != null) {
-                // FIXME: return correct offset when using absolute episode
-                // numbers.
-                var foundMapping = related.FirstOrDefault(animeListAnime => animeListAnime.MappingList?.Mapping?.FirstOrDefault(mapping => mapping.Start <= absoluteEpisodeNumber && mapping.End >= absoluteEpisodeNumber) != null);
+                // -----------------------------------------------------------------
+                // FIX 2: the original predicate compared only Start/End and ignored
+                // the season entirely. Start and End are plain ints, so they default
+                // to 0 when the attribute is absent, and FirstOrDefault walks the
+                // list in raw document order. The net effect was that the first
+                // entry owning a wide mapping table always won - for a franchise
+                // like Bleach that is the original 366-episode series - while
+                // sequel entries, which carry no <mapping-list> at all, could never
+                // be selected. Require a genuine range in the correct TVDB season,
+                // and return that mapping's offset rather than null.
+                // -----------------------------------------------------------------
+                AnimeListAnime foundMapping = null;
+                Mapping foundRange = null;
+                foreach (var animeListAnime in related) {
+                    var match = animeListAnime.MappingList?.Mapping?.FirstOrDefault(mapping =>
+                        mapping.Tvdbseason == seasonNumber &&
+                        mapping.Start > 0 && mapping.End > 0 &&
+                        mapping.Start <= absoluteEpisodeNumber &&
+                        mapping.End >= absoluteEpisodeNumber);
+                    if (match != null) {
+                        foundMapping = animeListAnime;
+                        foundRange = match;
+                        break;
+                    }
+                }
+
                 if (foundMapping != null) {
-                    return (int.TryParse(foundMapping.Anidbid, out var aniDbId) ? aniDbId : null, null);
+                    logger.LogInformation($"(AniDb) Absolute episode {absoluteEpisodeNumber} matched AniDB ID {foundMapping.Anidbid} (tvdbseason {seasonNumber}, range {foundRange.Start}-{foundRange.End}, offset {foundRange.Offset})");
+                    return (int.TryParse(foundMapping.Anidbid, out var aniDbId) ? aniDbId : null, foundRange.Offset);
                 } else {
-                    logger.LogWarning("(AniDb) Could not lookup using absolute episode number (reason: no mappings found)");
+                    logger.LogWarning($"(AniDb) Could not lookup using absolute episode number {absoluteEpisodeNumber} (reason: no mapping covers that episode within tvdbseason {seasonNumber})");
                     return SeasonLookup(logger, seasonNumber, episodeNumber, related);
                 }
             } else {
@@ -156,7 +265,7 @@ namespace jellyfin_ani_sync.Helpers {
             }
         }
 
-        private static (int? aniDbId, int? episodeOffset) SeasonLookup(ILogger logger, int seasonNumber, int episodeNumber, List<AnimeListAnime> related) {
+        internal static (int? aniDbId, int? episodeOffset) SeasonLookup(ILogger logger, int seasonNumber, int episodeNumber, List<AnimeListAnime> related) {
             logger.LogInformation("Looking up AniDB by season offset");
 
             // First, consider mappings from absolute-numbered seasons. If there
@@ -191,11 +300,20 @@ namespace jellyfin_ani_sync.Helpers {
                     episodeNumber - m.Offset <= m.End)
                 ?? tvdbSeasonMappings?.FirstOrDefault();
 
+            var resolvedOffset = specificMapping?.Offset ?? (int.TryParse(foundMapping?.Episodeoffset, out var episodeOffset)
+                ? episodeOffset
+                : (int?)null);
+
+            // FIX 3: make the outcome of this branch visible. NOTE: seasonNumber here
+            // is Jellyfin's season index, while defaulttvdbseason/tvdbseason in the XML
+            // are TVDB season numbers. If your metadata provider does not number
+            // seasons the way TVDB does, this lookup will silently pick the wrong
+            // entry - which is exactly why FIX 1 short-circuits it where possible.
+            logger.LogInformation($"(AniDb) Season lookup for tvdb season {seasonNumber}, episode {episodeNumber} resolved to AniDB ID {foundMapping?.Anidbid ?? "<none>"} ({foundMapping?.Name ?? "<none>"}) with offset {(resolvedOffset.HasValue ? resolvedOffset.Value.ToString() : "<none>")}");
+
             return (
                 int.TryParse(foundMapping?.Anidbid, out var aniDbId) ? aniDbId : null,
-                specificMapping?.Offset ?? (int.TryParse(foundMapping?.Episodeoffset, out var episodeOffset)
-                    ? episodeOffset
-                    : null)
+                resolvedOffset
             );
         }
 

--- a/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
@@ -15,7 +15,7 @@ namespace jellyfin_ani_sync.Helpers {
             string customArmServerBaseUrl = Plugin.Instance?.Configuration.armServerBaseUrl;
             if (!string.IsNullOrEmpty(customArmServerBaseUrl)) {
                 if (Uri.TryCreate(customArmServerBaseUrl, UriKind.Absolute, out Uri baseUri) && (baseUri.Scheme == Uri.UriSchemeHttp || baseUri.Scheme == Uri.UriSchemeHttps)) {
-                    baseUrl = baseUri.AbsoluteUri;
+                    baseUrl = baseUri.AbsoluteUri.TrimEnd('/');
                 } else {
                     logger.LogWarning($"ARM server base URL ({customArmServerBaseUrl}) could not be parsed. Confirm the URL is valid. Falling back to public API...");
                 }

--- a/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
@@ -15,7 +15,7 @@ namespace jellyfin_ani_sync.Helpers {
             string customArmServerBaseUrl = Plugin.Instance?.Configuration.armServerBaseUrl;
             if (!string.IsNullOrEmpty(customArmServerBaseUrl)) {
                 if (Uri.TryCreate(customArmServerBaseUrl, UriKind.Absolute, out Uri baseUri) && (baseUri.Scheme == Uri.UriSchemeHttp || baseUri.Scheme == Uri.UriSchemeHttps)) {
-                    baseUrl = baseUri.AbsoluteUri.TrimEnd('/');
+                    baseUrl = baseUri.AbsoluteUri;
                 } else {
                     logger.LogWarning($"ARM server base URL ({customArmServerBaseUrl}) could not be parsed. Confirm the URL is valid. Falling back to public API...");
                 }
@@ -31,10 +31,34 @@ namespace jellyfin_ani_sync.Helpers {
             StreamReader streamReader = new StreamReader(await response.Content.ReadAsStreamAsync());
             string streamText = await streamReader.ReadToEndAsync();
 
-            var deserializedResponse = JsonSerializer.Deserialize<OfflineDatabaseResponse>(streamText);
+            // FIX 8: the previous code reported success whenever the payload merely
+            // deserialised, which hid the case of a row that exists but carries no
+            // usable provider ID. ARM returns literal `null` for an unknown ID and a
+            // partially-populated object when the offline database has the entry but
+            // not yet the cross-references. Those are very different situations and
+            // both used to log "Retrieved provider IDs".
+            logger.LogInformation($"[ani-sync-diag] ARM {(int)response.StatusCode} for {source.ToString().ToLower()}={metadataId}, body: {(streamText.Length > 400 ? streamText.Substring(0, 400) + "..." : streamText)}");
+            if (!response.IsSuccessStatusCode) {
+                logger.LogWarning($"ARM server returned {(int)response.StatusCode}; treating as no result");
+                return null;
+            }
+
+            OfflineDatabaseResponse deserializedResponse;
+            try {
+                deserializedResponse = JsonSerializer.Deserialize<OfflineDatabaseResponse>(streamText);
+            } catch (JsonException e) {
+                logger.LogError($"Could not parse ARM server response: {e.Message}");
+                return null;
+            }
+
             if (deserializedResponse == null) return null;
+
+            logger.LogInformation($"[ani-sync-diag] ARM parsed -> anidb={Fmt(deserializedResponse.AniDb)}, anilist={Fmt(deserializedResponse.Anilist)}, myanimelist={Fmt(deserializedResponse.MyAnimeList)}, kitsu={Fmt(deserializedResponse.Kitsu)}");
+
             return deserializedResponse;
         }
+
+        private static string Fmt(int? value) => value?.ToString() ?? "<none>";
 
         public class OfflineDatabaseResponse {
             [JsonPropertyName("anilist")] public int? Anilist { get; set; }

--- a/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
+++ b/jellyfin-ani-sync/Helpers/AnimeOfflineDatabaseHelpers.cs
@@ -37,7 +37,7 @@ namespace jellyfin_ani_sync.Helpers {
             // partially-populated object when the offline database has the entry but
             // not yet the cross-references. Those are very different situations and
             // both used to log "Retrieved provider IDs".
-            logger.LogInformation($"[ani-sync-diag] ARM {(int)response.StatusCode} for {source.ToString().ToLower()}={metadataId}, body: {(streamText.Length > 400 ? streamText.Substring(0, 400) + "..." : streamText)}");
+            logger.LogDebug($"[ani-sync-diag] ARM {(int)response.StatusCode} for {source.ToString().ToLower()}={metadataId}, body: {(streamText.Length > 400 ? streamText.Substring(0, 400) + "..." : streamText)}");
             if (!response.IsSuccessStatusCode) {
                 logger.LogWarning($"ARM server returned {(int)response.StatusCode}; treating as no result");
                 return null;
@@ -53,7 +53,7 @@ namespace jellyfin_ani_sync.Helpers {
 
             if (deserializedResponse == null) return null;
 
-            logger.LogInformation($"[ani-sync-diag] ARM parsed -> anidb={Fmt(deserializedResponse.AniDb)}, anilist={Fmt(deserializedResponse.Anilist)}, myanimelist={Fmt(deserializedResponse.MyAnimeList)}, kitsu={Fmt(deserializedResponse.Kitsu)}");
+            logger.LogDebug($"[ani-sync-diag] ARM parsed -> anidb={Fmt(deserializedResponse.AniDb)}, anilist={Fmt(deserializedResponse.Anilist)}, myanimelist={Fmt(deserializedResponse.MyAnimeList)}, kitsu={Fmt(deserializedResponse.Kitsu)}");
 
             return deserializedResponse;
         }

--- a/jellyfin-ani-sync/UpdateProviderStatus.cs
+++ b/jellyfin-ani-sync/UpdateProviderStatus.cs
@@ -404,7 +404,7 @@ namespace jellyfin_ani_sync {
             var candidateTitles = new List<string>();
             if (_animeType == typeof(Episode)) {
                 candidateTitles.Add(episode.SeriesName);
-                candidateTitles.Add(episode.Series?.OriginalTitle);
+                if (episode.Series?.OriginalTitle != null) candidateTitles.Add(episode.Series.OriginalTitle);
             } else {
                 candidateTitles.Add(movie.Name);
                 candidateTitles.Add(movie.OriginalTitle);

--- a/jellyfin-ani-sync/UpdateProviderStatus.cs
+++ b/jellyfin-ani-sync/UpdateProviderStatus.cs
@@ -103,15 +103,18 @@ namespace jellyfin_ani_sync {
 
                 // FIX 4: diagnostics. Prints exactly which provider IDs Jellyfin holds at
                 // each level, plus the season count that drives the absolute-episode path.
-                if (_animeType == typeof(Episode)) {
+                // Logged at Debug: this runs on every played episode, and the information
+                // is only useful when investigating a mis-resolution. The IsEnabled guard
+                // keeps the interpolated strings from being built when Debug is off.
+                if (_animeType == typeof(Episode) && _logger.IsEnabled(LogLevel.Debug)) {
                     string Dump(Dictionary<string, string> ids) => ids == null || ids.Count == 0
                         ? "<none>"
                         : string.Join(", ", ids.Select(kv => $"{kv.Key}={kv.Value}"));
-                    _logger.LogInformation($"[ani-sync-diag] Series '{episode.Series?.Name}' providers: {Dump(episode.Series?.ProviderIds)}");
-                    _logger.LogInformation($"[ani-sync-diag] Season {episode.Season?.IndexNumber} providers: {Dump(episode.Season?.ProviderIds)}");
-                    _logger.LogInformation($"[ani-sync-diag] Episode {episode.IndexNumber} '{episode.Name}' providers: {Dump(episode.ProviderIds)}");
-                    _logger.LogInformation($"[ani-sync-diag] Series contains {episode.Series?.Children.OfType<Season>().Count()} season(s)");
-                    _logger.LogInformation($"[ani-sync-diag] Titles -> name: '{episode.SeriesName}', originalTitle: '{episode.Series?.OriginalTitle ?? "<none>"}'");
+                    _logger.LogDebug($"[ani-sync-diag] Series '{episode.Series?.Name}' providers: {Dump(episode.Series?.ProviderIds)}");
+                    _logger.LogDebug($"[ani-sync-diag] Season {episode.Season?.IndexNumber} providers: {Dump(episode.Season?.ProviderIds)}");
+                    _logger.LogDebug($"[ani-sync-diag] Episode {episode.IndexNumber} '{episode.Name}' providers: {Dump(episode.ProviderIds)}");
+                    _logger.LogDebug($"[ani-sync-diag] Series contains {episode.Series?.Children.OfType<Season>().Count()} season(s)");
+                    _logger.LogDebug($"[ani-sync-diag] Titles -> name: '{episode.SeriesName}', originalTitle: '{episode.Series?.OriginalTitle ?? "<none>"}'");
                 }
 
                 (int? aniDbId, int? episodeOffset) aniDbId = (null, null);

--- a/jellyfin-ani-sync/UpdateProviderStatus.cs
+++ b/jellyfin-ani-sync/UpdateProviderStatus.cs
@@ -101,6 +101,19 @@ namespace jellyfin_ani_sync {
                     return;
                 }
 
+                // FIX 4: diagnostics. Prints exactly which provider IDs Jellyfin holds at
+                // each level, plus the season count that drives the absolute-episode path.
+                if (_animeType == typeof(Episode)) {
+                    string Dump(Dictionary<string, string> ids) => ids == null || ids.Count == 0
+                        ? "<none>"
+                        : string.Join(", ", ids.Select(kv => $"{kv.Key}={kv.Value}"));
+                    _logger.LogInformation($"[ani-sync-diag] Series '{episode.Series?.Name}' providers: {Dump(episode.Series?.ProviderIds)}");
+                    _logger.LogInformation($"[ani-sync-diag] Season {episode.Season?.IndexNumber} providers: {Dump(episode.Season?.ProviderIds)}");
+                    _logger.LogInformation($"[ani-sync-diag] Episode {episode.IndexNumber} '{episode.Name}' providers: {Dump(episode.ProviderIds)}");
+                    _logger.LogInformation($"[ani-sync-diag] Series contains {episode.Series?.Children.OfType<Season>().Count()} season(s)");
+                    _logger.LogInformation($"[ani-sync-diag] Titles -> name: '{episode.SeriesName}', originalTitle: '{episode.Series?.OriginalTitle ?? "<none>"}'");
+                }
+
                 (int? aniDbId, int? episodeOffset) aniDbId = (null, null);
                 if (_animeType == typeof(Episode)
                         ? episode.ProviderIds != null &&
@@ -121,11 +134,11 @@ namespace jellyfin_ani_sync {
                         _logger.LogInformation("Retrieved provider IDs");
                     }
                 } else if (_animeType == typeof(Episode)
-                               ? (episode.Series.ProviderIds.ContainsKey("Tvdb") ||
-                                  episode.Season.ProviderIds.ContainsKey("Anidb") ||
-                                  episode.Series.ProviderIds.ContainsKey("Anidb"))
+                               ? (AnimeListHelpers.HasProviderId(episode.Series.ProviderIds, "Tvdb") ||
+                                  AnimeListHelpers.HasProviderId(episode.Season.ProviderIds, "Anidb") ||
+                                  AnimeListHelpers.HasProviderId(episode.Series.ProviderIds, "Anidb"))
                                : movie.ProviderIds != null &&
-                                 movie.ProviderIds.ContainsKey("Anidb")) {
+                                 AnimeListHelpers.HasProviderId(movie.ProviderIds, "Anidb")) {
                     AnimeListHelpers.AnimeListXml animeListXml = await AnimeListHelpers.GetAnimeListFileContents(_logger, _loggerFactory, _httpClientFactory, _applicationPaths);
                     aniDbId = _animeType == typeof(Episode)
                         ? await AnimeListHelpers.GetAniDbId(_logger, episode, episode.IndexNumber.Value, episode.Season.IndexNumber.Value, animeListXml)
@@ -139,7 +152,15 @@ namespace jellyfin_ani_sync {
                             };
                             _logger.LogWarning("Did not get provider IDs, defaulting to episode provided AniDb ID");
                         } else {
-                            _logger.LogInformation("Retrieved provider IDs");
+                            // FIX 8: distinguish "ARM gave us a usable ID" from "ARM gave us a
+                            // row that carries none". Only the former avoids the title-search
+                            // fallback, so reporting both as success made the fallback look
+                            // like a bug in ID resolution rather than a gap in the database.
+                            if (_apiIds.Anilist is null or 0 && _apiIds.MyAnimeList is null or 0 && _apiIds.Kitsu is null or 0) {
+                                _logger.LogWarning($"ARM server has a record for AniDb ID {aniDbId.aniDbId.Value} but no tracker IDs; falling back to title search");
+                            } else {
+                                _logger.LogInformation("Retrieved provider IDs");
+                            }
                         }
                     }
                 }
@@ -266,7 +287,23 @@ namespace jellyfin_ani_sync {
                                                 found = true;
                                                 break;
                                             }
-                                        } else if (matchingAnime.NumEpisodes < episode?.IndexNumber.Value) {
+                                        } else if (matchingAnime.NumEpisodes > 0 && matchingAnime.NumEpisodes < episode?.IndexNumber.Value) {
+                                            // FIX 9: NumEpisodes is a non-nullable int, so an unknown
+                                            // episode count arrives as 0 - which is the norm for a
+                                            // currently-airing show. Without the > 0 guard this branch
+                                            // fires on every episode of every airing series that reaches
+                                            // the title-search fallback.
+                                            //
+                                            // Walking cannot produce a correct answer in that case
+                                            // regardless: the loop computes the next cour's episode
+                                            // number as episodeCount - totalEpisodesWatched, and
+                                            // totalEpisodesWatched accumulates season.NumEpisodes. With
+                                            // 0 the offset is always 0, so the raw episode number gets
+                                            // sent to the sequel. The arithmetic requires a known
+                                            // length. When no sequel exists the code already recovers
+                                            // via isRootSeason; this guard applies that same judgement
+                                            // up front, so the outcome no longer depends on whether the
+                                            // entry happens to have a Sequel relation.
                                             _logger.LogInformation($"({ApiName}) Watched episode passes total episodes in season! Checking for additional seasons/cours...");
                                             // either we have found the wrong series (highly unlikely) or it is a multi cour series/Jellyfin has grouped next season into the current.
                                             int seasonEpisodeCounter = matchingAnime.NumEpisodes;
@@ -354,11 +391,33 @@ namespace jellyfin_ani_sync {
         /// <param name="movie">The movie if its a single episode movie.</param>
         /// <returns></returns>
         private bool TitleCheck(Anime anime, Episode episode, Movie movie) {
-            var title = _animeType == typeof(Episode) ? episode.SeriesName : movie.Name;
-            return CompareStrings(anime.Title, title) ||
-                   (anime.AlternativeTitles.En != null && CompareStrings(anime.AlternativeTitles.En, title)) ||
-                   (anime.AlternativeTitles.Ja != null && CompareStrings(anime.AlternativeTitles.Ja, title)) ||
-                   (anime.AlternativeTitles.Synonyms != null && anime.AlternativeTitles.Synonyms.Any(synonym => CompareStrings(synonym, title)));
+            // FIX 7: try every title Jellyfin holds for the item, not just the display
+            // name. Metadata providers such as Shokofin populate OriginalTitle with the
+            // series' native title, and AniList carries a native title for effectively
+            // every entry - so this matches even when the romanisations disagree
+            // (e.g. AniDB "Otome Kaijuu Caramelise" vs AniList "Otome Kaijuu Caraméliser").
+            // It lets a library display English or romaji titles while still resolving
+            // correctly, instead of forcing the whole library into one naming scheme.
+            var candidateTitles = new List<string>();
+            if (_animeType == typeof(Episode)) {
+                candidateTitles.Add(episode.SeriesName);
+                candidateTitles.Add(episode.Series?.OriginalTitle);
+            } else {
+                candidateTitles.Add(movie.Name);
+                candidateTitles.Add(movie.OriginalTitle);
+            }
+
+            foreach (var title in candidateTitles) {
+                if (string.IsNullOrWhiteSpace(title)) continue;
+                if (CompareStrings(anime.Title, title) ||
+                    (anime.AlternativeTitles.En != null && CompareStrings(anime.AlternativeTitles.En, title)) ||
+                    (anime.AlternativeTitles.Ja != null && CompareStrings(anime.AlternativeTitles.Ja, title)) ||
+                    (anime.AlternativeTitles.Synonyms != null && anime.AlternativeTitles.Synonyms.Any(synonym => CompareStrings(synonym, title)))) {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -738,7 +797,7 @@ namespace jellyfin_ani_sync {
         /// <param name="seasonNumber">Index of the season to get.</param>
         /// <returns>The different seasons anime or null if unable to retrieve the relations.</returns>
         internal async Task<Anime?> GetDifferentSeasonAnime(int animeId, int seasonNumber, string? alternativeId = null) {
-            _logger.LogInformation($"({ApiName}) Attempting to get season 1...");
+            _logger.LogInformation($"({ApiName}) Attempting to get season {seasonNumber}...");
             Anime retrievedSeason = await ApiCallHelpers.GetAnime(animeId, getRelated: true, alternativeId: alternativeId);
 
             if (retrievedSeason != null) {


### PR DESCRIPTION
### AI Disclaimer
All of the code fixes were made by Claude Opus 5. I do know some coding but I am by no means a C# programmer and cannot vouch for the style or implementation of this code. I do not take any credit for any code within my fork, I only wanted to fix the issues I was having with this plugin.

fixes https://github.com/vosmiic/jellyfin-ani-sync/issues/119 and I believe https://github.com/vosmiic/jellyfin-ani-sync/issues/128 https://github.com/vosmiic/jellyfin-ani-sync/issues/135 https://github.com/vosmiic/jellyfin-ani-sync/issues/165 https://github.com/vosmiic/jellyfin-ani-sync/issues/181 https://github.com/vosmiic/jellyfin-ani-sync/issues/215 https://github.com/vosmiic/jellyfin-ani-sync/issues/219

### Major Changes
- Return the season-level AniDB ID directly rather than using it only to locate an XML row and re-deriving from that row's siblings. `GetAniDbId` already prefers `Season.ProviderIds` and already lets a season ID bypass the `defaulttvdbseason` filter, so this extends existing intent one step further.
- Compare the mapping's TVDB season when matching absolute episode numbers, and return that mapping's offset 
- Resolve the correct entry inside a Shokofin merged season, where one Jellyfin season spans several AniDB series with continuous episode numbering.
- Case-insensitive provider ID lookup. Both AniDB metadata providers write `"AniDB"` while the plugin looked for `"Anidb"`.
- Case-insensitive on the AniDB lookup branch.
- Match titles against `OriginalTitle` as well as the display name, for title-search fallback. (Shokofin allows the option to add additional titles, untested with other providers)
- Skip cour walking when the API reports an unknown episode count.

### Diagnostic Changes
- Log provider IDs at series, season and episode level.
- Log what the season-offset lookup resolved to.
- Log the ARM server response, and warn when a record carries no tracker IDs rather than reporting success.

### Testing

- Added five unit tests covering XML resolution logic against real rows from two shows; test can be ran standalone.

`dotnet test` gives 72 total / 71 passing. The single failure is `GeneralFlowTests.UpdateAnimeReWatchingInProgress(AniList)`, which also fails on a clean upstream checkout: the code returns `Status.Rewatching` while the test expects `Status.Watching`. (Untouched in this branch)
