### PR TITLE
fix: update AniList anime status from 'Plan to watch' to 'Watching'

### DIFF
--- a/jellyfin-ani-sync/Helpers/ClassConversions.cs
+++ b/jellyfin-ani-sync/Helpers/ClassConversions.cs
@@ -37,7 +37,7 @@ namespace jellyfin_ani_sync.Helpers {
 
                 switch (aniListAnime.MediaListEntry.MediaListStatus) {
                     case AniListSearch.MediaListStatus.Current:
-                        anime.MyListStatus.Status = Status.Plan_to_watch;
+                        anime.MyListStatus.Status = Status.Watching;
                         break;
                     case AniListSearch.MediaListStatus.Completed:
                         anime.MyListStatus.Status = Status.Completed;


### PR DESCRIPTION
AniSync was incorrectly mapping Current as "Plan_to_watch", but Current should be "Watching" according to anilist API docs: https://docs.anilist.co/reference/enum/medialiststatus MediaListStatus