### PR TITLE
fix: only check rewatch completed if anime is not on plan to watch list

### DIFF
--- a/jellyfin-ani-sync/UpdateProviderStatus.cs
+++ b/jellyfin-ani-sync/UpdateProviderStatus.cs
@@ -450,9 +450,7 @@ namespace jellyfin_ani_sync {
                         updated = true;
                         await UpdateAnimeStatus(detectedAnime, episodeNumber);
                     }
-                }
-
-                if (ApiName != ApiName.Annict) {
+                } else if (ApiName != ApiName.Annict) {
                     // also check if rewatch completed is checked
                     _logger.LogInformation($"({ApiName}) {(_animeType == typeof(Episode) ? "Series" : "Movie")} ({GetAnimeTitle(detectedAnime)}) not found in plan to watch list{(_userConfig.RewatchCompleted ? ", checking completed list.." : null)}");
                     updated = true;


### PR DESCRIPTION
## When an anime is found on "Plan to Watch" list AniSync still checks "completed" list

I don't think there is a state where an anime can be both "Completed" and in "Plan to Watch" state.
Added a simple "else if" instead of second "if"

If any other providers support that kind of state the solution could be changed to print a different message, but then again, we've already changed anime status or at least attempted to.

Log:
```
[14:31:37] [INF] [50] jellyfin_ani_sync.UpdateProviderStatus: (AniList) Series (Mushoku Tensei: Jobless Reincarnation) found on plan to watch list
[14:31:37] [INF] [50] jellyfin_ani_sync.UpdateProviderStatus: (AniList) Provider reports episode already watched; not updating
[14:31:37] [ERR] [50] jellyfin_ani_sync.UpdateProviderStatus: (AniList) Could not update anime status
[14:31:37] [INF] [50] jellyfin_ani_sync.UpdateProviderStatus: (AniList) Series (Mushoku Tensei: Jobless Reincarnation) not found in plan to watch list, checking completed list..
[14:31:37] [INF] [50] jellyfin_ani_sync.UpdateProviderStatus: (AniList) Series (Mushoku Tensei: Jobless Reincarnation) found, but provider reports episode already watched. Skipping
```
Log is reporting both "found on plan to watch" and then "not found on plan to watch"

I've tested the plugin after fix, reports and updates correctly both "Plan to Watch" and "Completed>ReWatching" at least for AniList.

p.s. If provider reports episode as already watched I think it shouldn't be an ERR state:
```
[14:31:37] [INF] [50] jellyfin_ani_sync.UpdateProviderStatus: (AniList) Provider reports episode already watched; not updating
[14:31:37] [ERR] [50] jellyfin_ani_sync.UpdateProviderStatus: (AniList) Could not update anime status
```
I didn't change this in this PR, since it's not related to the original issue